### PR TITLE
Remove hardcoding of intra_op_num_threads to 1.

### DIFF
--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -140,8 +140,6 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
   THROW_IF_BACKEND_MODEL_ORT_ERROR(ort_api->CreateSessionOptions(&soptions));
   session_options_.reset(soptions);
 
-  THROW_IF_BACKEND_MODEL_ORT_ERROR(ort_api->SetIntraOpNumThreads(soptions, 1));
-
   GraphOptimizationLevel optimization_level =
       GraphOptimizationLevel::ORT_ENABLE_ALL;
   {


### PR DESCRIPTION
*Description:* This is problematic when OpenMP is disabled in the ORT build as it restricts the number of threads to 1 as opposed to letting ORT choose a reasonable default (number of physical cores). When OpenMP is enabled calling this API is inconsequential. Ideally we would like to make this configurable; this will be addressed in the upcoming PRs.

*Motivation and Context:* Allow ORT (without OpenMP) to be tested with Triton with the default settings.