### PR TITLE
Update ortbackend

### DIFF
--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -832,8 +832,8 @@ ModelInstanceState::ValidateBooleanSequenceControl(
   std::string tensor_datatype;
   RETURN_IF_ERROR(GetBooleanSequenceControlProperties(
       sequence_batching, model_state_->Name(), control_kind, required,
-      &tensor_name, &tensor_datatype, nullptr, nullptr, nullptr, nullptr,
-      nullptr, nullptr));
+      &tensor_name, &tensor_datatype, nullptr, nullptr, nullptr, nullptr));
+
   *have_control = !tensor_name.empty();
   if (*have_control) {
     OnnxTensorInfoMap input_tensor_infos;

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -832,7 +832,8 @@ ModelInstanceState::ValidateBooleanSequenceControl(
   std::string tensor_datatype;
   RETURN_IF_ERROR(GetBooleanSequenceControlProperties(
       sequence_batching, model_state_->Name(), control_kind, required,
-      &tensor_name, &tensor_datatype, nullptr, nullptr, nullptr, nullptr));
+      &tensor_name, &tensor_datatype, nullptr, nullptr, nullptr, nullptr,
+      nullptr, nullptr));
   *have_control = !tensor_name.empty();
   if (*have_control) {
     OnnxTensorInfoMap input_tensor_infos;

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -32,13 +32,6 @@ import re
 
 FLAGS = None
 
-## TEMPORARY: Using the master commit id until ORT 1.9 release to enable ORT backend with TRT 8.0 support.
-# For ORT versions 1.8.0 and below the behavior will remain same. For ORT version 1.8.1 we will
-# use this commit from master branch instead of using rel-1.8.1
-# From ORT 1.9 onwards we will switch back to using rel-* branches
-ONNXRuntime_MasterCommitId = "d14b08d09cee43b42fa9ac361a78d1cbdbceddef"
-
-
 def target_platform():
     if FLAGS.target_platform is not None:
         return FLAGS.target_platform
@@ -135,6 +128,10 @@ RUN wget ${INTEL_COMPUTE_RUNTIME_URL}/intel-gmmlib_19.3.2_amd64.deb && \
     wget ${INTEL_COMPUTE_RUNTIME_URL}/intel-ocloc_19.41.14441_amd64.deb && \
     dpkg -i *.deb && rm -rf *.deb
 '''
+   ## TEMPORARY: Using the tensorrt-8.0 brnach until ORT 1.9 release to enable ORT backend with TRT 8.0 support.
+   # For ORT versions 1.8.0 and below the behavior will remain same. For ORT version 1.8.1 we will
+   # use this commit from master branch instead of using rel-1.8.1
+   # From ORT 1.9 onwards we will switch back to using rel-* branches
     if FLAGS.ort_version == "1.8.1":
         df += '''
     #
@@ -142,10 +139,8 @@ RUN wget ${INTEL_COMPUTE_RUNTIME_URL}/intel-gmmlib_19.3.2_amd64.deb && \
     #
     ARG ONNXRUNTIME_VERSION
     ARG ONNXRUNTIME_REPO
-    ARG ONNXRUNTIME_MASTERCOMMIT
 
-    RUN git clone -b master --recursive ${ONNXRUNTIME_REPO} onnxruntime && \
-        (cd onnxruntime && git reset --hard ${ONNXRUNTIME_MASTERCOMMIT}) && \
+    RUN git clone -b tensorrt-8.0 --recursive ${ONNXRUNTIME_REPO} onnxruntime && \
         (cd onnxruntime && git submodule update --init --recursive)
 
        '''
@@ -282,6 +277,11 @@ RUN mkdir -p /opt/onnxruntime/test && \
 
 def dockerfile_for_windows(output_file):
     df = dockerfile_common()
+
+    ## TEMPORARY: Using the tensorrt-8.0 brnach until ORT 1.9 release to enable ORT backend with TRT 8.0 support.
+    # For ORT versions 1.8.0 and below the behavior will remain same. For ORT version 1.8.1 we will
+    # use this commit from master branch instead of using rel-1.8.1
+    # From ORT 1.9 onwards we will switch back to using rel-* branches
     if FLAGS.ort_version == "1.8.1":
         df += '''
 SHELL ["cmd", "/S", "/C"]
@@ -291,9 +291,8 @@ SHELL ["cmd", "/S", "/C"]
 #
 ARG ONNXRUNTIME_VERSION
 ARG ONNXRUNTIME_REPO
-ARG ONNXRUNTIME_MASTERCOMMIT
-RUN git clone -b master --recursive %ONNXRUNTIME_REPO% onnxruntime && \
-    (cd onnxruntime && git reset --hard %ONNXRUNTIME_MASTERCOMMIT%) && \
+
+RUN git clone -b tensorrt-8.0 --recursive %ONNXRUNTIME_REPO% onnxruntime && \
     (cd onnxruntime && git submodule update --init --recursive)
 '''
     else:

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -42,9 +42,8 @@ def dockerfile_common():
     df = '''
 ARG BASE_IMAGE={}
 ARG ONNXRUNTIME_VERSION={}
-ARG ONNXRUNTIME_MASTERCOMMIT={}
 ARG ONNXRUNTIME_REPO=https://github.com/microsoft/onnxruntime
-'''.format(FLAGS.triton_container, FLAGS.ort_version, ONNXRuntime_MasterCommitId)
+'''.format(FLAGS.triton_container, FLAGS.ort_version)
 
     if FLAGS.ort_openvino is not None:
         df += '''
@@ -130,7 +129,7 @@ RUN wget ${INTEL_COMPUTE_RUNTIME_URL}/intel-gmmlib_19.3.2_amd64.deb && \
 '''
    ## TEMPORARY: Using the tensorrt-8.0 brnach until ORT 1.9 release to enable ORT backend with TRT 8.0 support.
    # For ORT versions 1.8.0 and below the behavior will remain same. For ORT version 1.8.1 we will
-   # use this commit from master branch instead of using rel-1.8.1
+   # use tensorrt-8.0 branch instead of using rel-1.8.1
    # From ORT 1.9 onwards we will switch back to using rel-* branches
     if FLAGS.ort_version == "1.8.1":
         df += '''
@@ -280,7 +279,7 @@ def dockerfile_for_windows(output_file):
 
     ## TEMPORARY: Using the tensorrt-8.0 brnach until ORT 1.9 release to enable ORT backend with TRT 8.0 support.
     # For ORT versions 1.8.0 and below the behavior will remain same. For ORT version 1.8.1 we will
-    # use this commit from master branch instead of using rel-1.8.1
+    # use tensorrt-8.0 branch instead of using rel-1.8.1
     # From ORT 1.9 onwards we will switch back to using rel-* branches
     if FLAGS.ort_version == "1.8.1":
         df += '''


### PR DESCRIPTION
Enables trt 8.0 for ORT backend. TRT 8.0 support is not yet available in a released version of ort therefore using tensorrt-8.0 branch in ort instead of the rel-* branches until ORT 1.9 release. 