### PR TITLE
Return early if ortrun bumps into a inference error

### DIFF
--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -858,7 +858,7 @@ ModelInstanceState::ValidateBooleanSequenceControl(
   std::string tensor_datatype;
   RETURN_IF_ERROR(GetBooleanSequenceControlProperties(
       sequence_batching, model_state_->Name(), control_kind, required,
-      &tensor_name, &tensor_datatype, nullptr, nullptr, nullptr, nullptr
+      &tensor_name, &tensor_datatype, nullptr, nullptr, nullptr, nullptr,
       nullptr, nullptr));
   *have_control = !tensor_name.empty();
   if (*have_control) {

--- a/src/onnxruntime_utils.h
+++ b/src/onnxruntime_utils.h
@@ -37,23 +37,23 @@ namespace triton { namespace backend { namespace onnxruntime {
 
 extern const OrtApi* ort_api;
 
-#define RESPOND_ALL_AND_RETURN_IF_ERROR(                                       \
-    REQUESTS, REQUEST_COUNT, RESPONSES, S)                                     \
-  do {                                                                         \
-    TRITONSERVER_Error* raarie_err__ = (S);                                    \
-    if (raarie_err__ != nullptr) {                                             \
-      SendErrorForResponses(RESPONSES, REQUEST_COUNT, raarie_err__);           \
-      for (uint32_t r = 0; r < REQUEST_COUNT; ++r) {                           \
-        if (RESPONSES[r] != nullptr) {                                         \
-        LOG_IF_ERROR(                                                          \
-            TRITONBACKEND_RequestRelease(                                      \
-                REQUESTS[r], TRITONSERVER_REQUEST_RELEASE_ALL),                \
-            "failed releasing request");                                       \
-        REQUESTS[r] = nullptr;                                                 \
-        }                                                                      \
-      }                                                                        \
-      return;                                                                  \
-    }                                                                          \
+#define RESPOND_ALL_AND_RETURN_IF_ERROR(                            \
+    REQUESTS, REQUEST_COUNT, RESPONSES, S)                          \
+  do {                                                              \
+    TRITONSERVER_Error* raarie_err__ = (S);                         \
+    if (raarie_err__ != nullptr) {                                  \
+      SendErrorForResponses(RESPONSES, REQUEST_COUNT, raarie_err__);\
+      for (uint32_t r = 0; r < REQUEST_COUNT; ++r) {                \
+        if (RESPONSES[r] != nullptr) {                              \
+        LOG_IF_ERROR(                                               \
+            TRITONBACKEND_RequestRelease(                           \
+                REQUESTS[r], TRITONSERVER_REQUEST_RELEASE_ALL),     \
+            "failed releasing request");                            \
+        REQUESTS[r] = nullptr;                                      \
+        }                                                           \
+      }                                                             \
+      return;                                                       \
+    }                                                               \
   } while (false) 
 
 #define RESPOND_ALL_AND_RETURN_IF_ORT_ERROR(                               \

--- a/src/onnxruntime_utils.h
+++ b/src/onnxruntime_utils.h
@@ -50,6 +50,7 @@ extern const OrtApi* ort_api;
                   response, TRITONSERVER_RESPONSE_COMPLETE_FINAL, \
                   raarie_err__),                                  \
               "failed to send ONNXRuntime backend response");     \
+          response = nullptr;                                     \
         }                                                         \
         LOG_IF_ERROR(                                             \
             TRITONBACKEND_RequestRelease(                         \


### PR DESCRIPTION
**Description**
Make OrtRun return error if any. Besides, return early if OrtRun fails.

The full server log after this fix: 
[server_log.txt](https://github.com/triton-inference-server/onnxruntime_backend/files/7214715/server_log.txt)

The sever will last even if ortrun fails:
```
I0921 20:09:01.361565 1 grpc_server.cc:4111] Started GRPCInferenceService at 0.0.0.0:8001
I0921 20:09:01.361802 1 http_server.cc:2803] Started HTTPService at 0.0.0.0:8000
I0921 20:09:01.403248 1 http_server.cc:162] Started Metrics Service at 0.0.0.0:8002
2021-09-21 20:09:26.315850258 [E:onnxruntime:, sequential_executor.cc:339 Execute] Non-zero status code returned while running Gather node. Name:'bert/embeddings/GatherV2' Status Message: indices element out of data bounds, idx=-1420042007188224409 must be within the inclusive range [-30522,30521]
```

However, if it returns early and then I close the server, the sever will complain as follows:
```
I0921 20:24:49.417818 1 server.cc:249] Timeout 29: Found 1 live models and 0 in-flight non-inference requests
I0921 20:24:50.417946 1 server.cc:249] Timeout 28: Found 1 live models and 0 in-flight non-inference requests
I0921 20:24:51.418066 1 server.cc:249] Timeout 27: Found 1 live models and 0 in-flight non-inference requests
...
I0921 20:25:16.421283 1 server.cc:249] Timeout 2: Found 1 live models and 0 in-flight non-inference requests
I0921 20:25:17.421419 1 server.cc:249] Timeout 1: Found 1 live models and 0 in-flight non-inference requests
I0921 20:25:18.421544 1 server.cc:249] Timeout 0: Found 1 live models and 0 in-flight non-inference requests
E0921 20:25:18.421589 1 main.cc:1571] failed to stop server: Internal - Exit timeout expired. Exiting immediately.
```
Since server does have a live model which failed, is this expected? If not, perhaps there is more action (like closing the live model) for returning early.

Update: before early return, add request release to let server close gracefully

**Motivation**
https://github.com/triton-inference-server/onnxruntime_backend/issues/69 A ORT inference causes Triton server to crash. Although ORT inference fails, the server should not crash and last. I can repro this kind of crash while testing certain bert model with Gather node error (indices element out of data bounds).
