### PR TITLE
update tensorrt parser to support TRT 8.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,13 +58,19 @@ project(tritononnxruntimebackend LANGUAGES C CXX)
 #         TRITON_BUILD_CUDA_HOME="C:\Program Files\NVIDIA GPU Computing Toolkit\v11.1"
 #
 #   - If you want TensorRT support set
-#     TRITON_ENABLE_ONNXRUNTIME_TENSORRT=ON and set
-#     TRITON_BUILD_TENSORRT_HOME.
+#     TRITON_ENABLE_ONNXRUNTIME_TENSORRT=ON and set TRITON_BUILD_TENSORRT_HOME.
+#
 #     Optionally set TRITON_ONNX_TENSORRT_REPO_TAG to specify a branch in https://github.com/onnx/onnx-tensorrt repo
 #     example:
 #         TRITON_ONNX_TENSORRT_REPO_TAG=master
 #     This enables using a version of tensorrt which is not yet supported in ONNXRuntime release branch.
 #     By default we pick the default branch which comes with the requested version of onnxruntime.
+#
+#     Optionally set TRITON_TENSORRT_VERSION to specify the verison of TRT which is being used. 
+#     This along with TRITON_BUILD_ONNXRUNTIME_VERSION is used to pick the right onnx tensorrt parser version. 
+#     When TRITON_ONNX_TENSORRT_REPO_TAG is set TRITON_TENSORRT_VERSION is ignored. 
+#     When neither TRITON_ONNX_TENSORRT_REPO_TAG or TRITON_TENSORRT_VERSION are set 
+#     the default parser version which comes with ORT is picked.
 #
 #   - If you want OpenVINO support set
 #     TRITON_ENABLE_ONNXRUNTIME_OPENVINO=ON and set
@@ -91,6 +97,7 @@ set(TRITON_BUILD_CUDNN_HOME "" CACHE PATH "Path to CUDNN install")
 set(TRITON_BUILD_TENSORRT_HOME "" CACHE PATH "Path to TensorRT install")
 set(TRITON_ONNXRUNTIME_INCLUDE_PATHS "" CACHE PATH "Paths to ONNXRuntime includes")
 set(TRITON_ONNX_TENSORRT_REPO_TAG "" CACHE STRING "Tag for onnx-tensorrt repo")
+set(TRITON_TENSORRT_VERSION "" CACHE STRING "TRT version for this build.")
 set(TRITON_ONNXRUNTIME_LIB_PATHS "" CACHE PATH "Paths to ONNXRuntime libraries")
 
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
@@ -337,7 +344,7 @@ if(TRITON_ONNXRUNTIME_DOCKER_BUILD)
     add_custom_command(
       OUTPUT
         onnxruntime/lib/${ONNXRUNTIME_LIBRARY}
-      COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/gen_ort_dockerfile.py --triton-container="${TRITON_BUILD_CONTAINER}" --ort-version="${TRITON_BUILD_ONNXRUNTIME_VERSION}" --onnx-tensorrt-tag="${TRITON_ONNX_TENSORRT_REPO_TAG}" ${_GEN_FLAGS} --output=Dockerfile.ort ${ENABLE_GPU_EXTRA_ARGS}
+      COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/gen_ort_dockerfile.py --triton-container="${TRITON_BUILD_CONTAINER}" --ort-version="${TRITON_BUILD_ONNXRUNTIME_VERSION}" --trt-version="${TRITON_TENSORRT_VERSION}" --onnx-tensorrt-tag="${TRITON_ONNX_TENSORRT_REPO_TAG}" ${_GEN_FLAGS} --output=Dockerfile.ort ${ENABLE_GPU_EXTRA_ARGS}
       COMMAND docker build --memory ${TRITON_ONNXRUNTIME_DOCKER_MEMORY} --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE} --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE}_cache0 --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE}_cache1 -t ${TRITON_ONNXRUNTIME_DOCKER_IMAGE} -f ./Dockerfile.ort ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND powershell.exe -noprofile -c "docker rm onnxruntime_backend_ort > $null 2>&1; if ($LASTEXITCODE) { 'error ignored...' }; exit 0"
       COMMAND docker create --name onnxruntime_backend_ort ${TRITON_ONNXRUNTIME_DOCKER_IMAGE}
@@ -350,7 +357,7 @@ if(TRITON_ONNXRUNTIME_DOCKER_BUILD)
     add_custom_command(
       OUTPUT
         onnxruntime/lib/${ONNXRUNTIME_LIBRARY}
-      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/gen_ort_dockerfile.py --triton-container="${TRITON_BUILD_CONTAINER}" --ort-version="${TRITON_BUILD_ONNXRUNTIME_VERSION}" --ort-build-config="${CMAKE_BUILD_TYPE}" --onnx-tensorrt-tag="${TRITON_ONNX_TENSORRT_REPO_TAG}" ${_GEN_FLAGS} --output=Dockerfile.ort ${ENABLE_GPU_EXTRA_ARGS}
+      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/gen_ort_dockerfile.py  --ort-build-config="${CMAKE_BUILD_TYPE}" --triton-container="${TRITON_BUILD_CONTAINER}" --ort-version="${TRITON_BUILD_ONNXRUNTIME_VERSION}" --trt-version="${TRITON_TENSORRT_VERSION}" --onnx-tensorrt-tag="${TRITON_ONNX_TENSORRT_REPO_TAG}" ${_GEN_FLAGS} --output=Dockerfile.ort ${ENABLE_GPU_EXTRA_ARGS}
       COMMAND docker build --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE} --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE}_cache0 --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE}_cache1 -t ${TRITON_ONNXRUNTIME_DOCKER_IMAGE} -f ./Dockerfile.ort ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND docker rm onnxruntime_backend_ort || echo 'error ignored...' || true
       COMMAND docker create --name onnxruntime_backend_ort ${TRITON_ONNXRUNTIME_DOCKER_IMAGE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,11 @@ project(tritononnxruntimebackend LANGUAGES C CXX)
 #   - If you want TensorRT support set
 #     TRITON_ENABLE_ONNXRUNTIME_TENSORRT=ON and set
 #     TRITON_BUILD_TENSORRT_HOME.
+#     Optionally set TRITON_ONNX_TENSORRT_REPO_TAG to branch in https://github.com/onnx/onnx-tensorrt repo
+#     example:
+#         TRITON_ONNX_TENSORRT_REPO_TAG=master
+#     This enables using a version of tensorrt which is not yet supported in ONNXRuntime release branch.
+#     By default we pick the default branch which comes with the requested version of onnxruntime.
 #
 #   - If you want OpenVINO support set
 #     TRITON_ENABLE_ONNXRUNTIME_OPENVINO=ON and set
@@ -85,6 +90,7 @@ set(TRITON_BUILD_CUDA_HOME "" CACHE PATH "Path to CUDA install")
 set(TRITON_BUILD_CUDNN_HOME "" CACHE PATH "Path to CUDNN install")
 set(TRITON_BUILD_TENSORRT_HOME "" CACHE PATH "Path to TensorRT install")
 set(TRITON_ONNXRUNTIME_INCLUDE_PATHS "" CACHE PATH "Paths to ONNXRuntime includes")
+set(TRITON_ONNX_TENSORRT_REPO_TAG "" CACHE STRING "Tag for onnx-tensorrt repo")
 set(TRITON_ONNXRUNTIME_LIB_PATHS "" CACHE PATH "Paths to ONNXRuntime libraries")
 
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
@@ -331,7 +337,7 @@ if(TRITON_ONNXRUNTIME_DOCKER_BUILD)
     add_custom_command(
       OUTPUT
         onnxruntime/lib/${ONNXRUNTIME_LIBRARY}
-      COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/gen_ort_dockerfile.py --triton-container="${TRITON_BUILD_CONTAINER}" --ort-version="${TRITON_BUILD_ONNXRUNTIME_VERSION}" ${_GEN_FLAGS} --output=Dockerfile.ort ${ENABLE_GPU_EXTRA_ARGS}
+      COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/gen_ort_dockerfile.py --triton-container="${TRITON_BUILD_CONTAINER}" --ort-version="${TRITON_BUILD_ONNXRUNTIME_VERSION}" --onnx-tensorrt-tag="${TRITON_ONNX_TENSORRT_REPO_TAG}" ${_GEN_FLAGS} --output=Dockerfile.ort ${ENABLE_GPU_EXTRA_ARGS}
       COMMAND docker build --memory ${TRITON_ONNXRUNTIME_DOCKER_MEMORY} --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE} --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE}_cache0 --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE}_cache1 -t ${TRITON_ONNXRUNTIME_DOCKER_IMAGE} -f ./Dockerfile.ort ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND powershell.exe -noprofile -c "docker rm onnxruntime_backend_ort > $null 2>&1; if ($LASTEXITCODE) { 'error ignored...' }; exit 0"
       COMMAND docker create --name onnxruntime_backend_ort ${TRITON_ONNXRUNTIME_DOCKER_IMAGE}
@@ -344,7 +350,7 @@ if(TRITON_ONNXRUNTIME_DOCKER_BUILD)
     add_custom_command(
       OUTPUT
         onnxruntime/lib/${ONNXRUNTIME_LIBRARY}
-      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/gen_ort_dockerfile.py --triton-container="${TRITON_BUILD_CONTAINER}" --ort-version="${TRITON_BUILD_ONNXRUNTIME_VERSION}" --ort-build-config="${CMAKE_BUILD_TYPE}" ${_GEN_FLAGS} --output=Dockerfile.ort ${ENABLE_GPU_EXTRA_ARGS}
+      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/gen_ort_dockerfile.py --triton-container="${TRITON_BUILD_CONTAINER}" --ort-version="${TRITON_BUILD_ONNXRUNTIME_VERSION}" --ort-build-config="${CMAKE_BUILD_TYPE}" --onnx-tensorrt-tag="${TRITON_ONNX_TENSORRT_REPO_TAG}" ${_GEN_FLAGS} --output=Dockerfile.ort ${ENABLE_GPU_EXTRA_ARGS}
       COMMAND docker build --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE} --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE}_cache0 --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE}_cache1 -t ${TRITON_ONNXRUNTIME_DOCKER_IMAGE} -f ./Dockerfile.ort ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND docker rm onnxruntime_backend_ort || echo 'error ignored...' || true
       COMMAND docker create --name onnxruntime_backend_ort ${TRITON_ONNXRUNTIME_DOCKER_IMAGE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,10 +66,10 @@ project(tritononnxruntimebackend LANGUAGES C CXX)
 #     This enables using a version of tensorrt which is not yet supported in ONNXRuntime release branch.
 #     By default we pick the default branch which comes with the requested version of onnxruntime.
 #
-#     Optionally set TRITON_TENSORRT_VERSION to specify the verison of TRT which is being used. 
+#     Optionally set TRT_VERSION to specify the verison of TRT which is being used. 
 #     This along with TRITON_BUILD_ONNXRUNTIME_VERSION is used to pick the right onnx tensorrt parser version. 
-#     When TRITON_ONNX_TENSORRT_REPO_TAG is set TRITON_TENSORRT_VERSION is ignored. 
-#     When neither TRITON_ONNX_TENSORRT_REPO_TAG or TRITON_TENSORRT_VERSION are set 
+#     When TRITON_ONNX_TENSORRT_REPO_TAG is set TRT_VERSION is ignored. 
+#     When neither TRITON_ONNX_TENSORRT_REPO_TAG or TRT_VERSION are set 
 #     the default parser version which comes with ORT is picked.
 #
 #   - If you want OpenVINO support set
@@ -97,7 +97,7 @@ set(TRITON_BUILD_CUDNN_HOME "" CACHE PATH "Path to CUDNN install")
 set(TRITON_BUILD_TENSORRT_HOME "" CACHE PATH "Path to TensorRT install")
 set(TRITON_ONNXRUNTIME_INCLUDE_PATHS "" CACHE PATH "Paths to ONNXRuntime includes")
 set(TRITON_ONNX_TENSORRT_REPO_TAG "" CACHE STRING "Tag for onnx-tensorrt repo")
-set(TRITON_TENSORRT_VERSION "" CACHE STRING "TRT version for this build.")
+set(TRT_VERSION "" CACHE STRING "TRT version for this build.")
 set(TRITON_ONNXRUNTIME_LIB_PATHS "" CACHE PATH "Paths to ONNXRuntime libraries")
 
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
@@ -344,7 +344,7 @@ if(TRITON_ONNXRUNTIME_DOCKER_BUILD)
     add_custom_command(
       OUTPUT
         onnxruntime/lib/${ONNXRUNTIME_LIBRARY}
-      COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/gen_ort_dockerfile.py --triton-container="${TRITON_BUILD_CONTAINER}" --ort-version="${TRITON_BUILD_ONNXRUNTIME_VERSION}" --trt-version="${TRITON_TENSORRT_VERSION}" --onnx-tensorrt-tag="${TRITON_ONNX_TENSORRT_REPO_TAG}" ${_GEN_FLAGS} --output=Dockerfile.ort ${ENABLE_GPU_EXTRA_ARGS}
+      COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/tools/gen_ort_dockerfile.py --triton-container="${TRITON_BUILD_CONTAINER}" --ort-version="${TRITON_BUILD_ONNXRUNTIME_VERSION}" --trt-version="${TRT_VERSION}" --onnx-tensorrt-tag="${TRITON_ONNX_TENSORRT_REPO_TAG}" ${_GEN_FLAGS} --output=Dockerfile.ort ${ENABLE_GPU_EXTRA_ARGS}
       COMMAND docker build --memory ${TRITON_ONNXRUNTIME_DOCKER_MEMORY} --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE} --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE}_cache0 --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE}_cache1 -t ${TRITON_ONNXRUNTIME_DOCKER_IMAGE} -f ./Dockerfile.ort ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND powershell.exe -noprofile -c "docker rm onnxruntime_backend_ort > $null 2>&1; if ($LASTEXITCODE) { 'error ignored...' }; exit 0"
       COMMAND docker create --name onnxruntime_backend_ort ${TRITON_ONNXRUNTIME_DOCKER_IMAGE}
@@ -357,7 +357,7 @@ if(TRITON_ONNXRUNTIME_DOCKER_BUILD)
     add_custom_command(
       OUTPUT
         onnxruntime/lib/${ONNXRUNTIME_LIBRARY}
-      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/gen_ort_dockerfile.py  --ort-build-config="${CMAKE_BUILD_TYPE}" --triton-container="${TRITON_BUILD_CONTAINER}" --ort-version="${TRITON_BUILD_ONNXRUNTIME_VERSION}" --trt-version="${TRITON_TENSORRT_VERSION}" --onnx-tensorrt-tag="${TRITON_ONNX_TENSORRT_REPO_TAG}" ${_GEN_FLAGS} --output=Dockerfile.ort ${ENABLE_GPU_EXTRA_ARGS}
+      COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tools/gen_ort_dockerfile.py  --ort-build-config="${CMAKE_BUILD_TYPE}" --triton-container="${TRITON_BUILD_CONTAINER}" --ort-version="${TRITON_BUILD_ONNXRUNTIME_VERSION}" --trt-version="${TRT_VERSION}" --onnx-tensorrt-tag="${TRITON_ONNX_TENSORRT_REPO_TAG}" ${_GEN_FLAGS} --output=Dockerfile.ort ${ENABLE_GPU_EXTRA_ARGS}
       COMMAND docker build --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE} --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE}_cache0 --cache-from=${TRITON_ONNXRUNTIME_DOCKER_IMAGE}_cache1 -t ${TRITON_ONNXRUNTIME_DOCKER_IMAGE} -f ./Dockerfile.ort ${CMAKE_CURRENT_SOURCE_DIR}
       COMMAND docker rm onnxruntime_backend_ort || echo 'error ignored...' || true
       COMMAND docker create --name onnxruntime_backend_ort ${TRITON_ONNXRUNTIME_DOCKER_IMAGE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ project(tritononnxruntimebackend LANGUAGES C CXX)
 #   - If you want TensorRT support set
 #     TRITON_ENABLE_ONNXRUNTIME_TENSORRT=ON and set
 #     TRITON_BUILD_TENSORRT_HOME.
-#     Optionally set TRITON_ONNX_TENSORRT_REPO_TAG to branch in https://github.com/onnx/onnx-tensorrt repo
+#     Optionally set TRITON_ONNX_TENSORRT_REPO_TAG to specify a branch in https://github.com/onnx/onnx-tensorrt repo
 #     example:
 #         TRITON_ONNX_TENSORRT_REPO_TAG=master
 #     This enables using a version of tensorrt which is not yet supported in ONNXRuntime release branch.

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -536,7 +536,7 @@ if __name__ == '__main__':
 
     # if a tag is provided by the user, then simply use it
     # if the tag is empty - check whether there is an entry in the ORT_TO_TRTPARSER_VERSION_MAP
-    # map cprresponding to ort version + triton container version combo. If yes then use it
+    # map corresponding to ort version + triton container version combo. If yes then use it
     # otherwise we leave it empty and use the defaults from ort
     if FLAGS.onnx_tensorrt_tag == "" and FLAGS.ort_version in ORT_TO_TRTPARSER_VERSION_MAP.keys(): 
         container_version = re.search('nvcr.io/nvidia/tritonserver:(.+?)-py3-min', FLAGS.triton_container)

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -34,7 +34,7 @@ FLAGS = None
 
 ORT_TO_TRTPARSER_VERSION_MAP = {
     '1.9.1': (
-        '21.12',         # Triton container version
+        '8.2',         # TensorRT version
         'release/8.2-EA' # ONNX-Tensorrt parser version
     )
 }
@@ -477,10 +477,6 @@ if __name__ == '__main__':
                         type=str,
                         required=True,
                         help='ORT version.')
-    parser.add_argument('--onnx-tensorrt-tag',
-                        type=str,
-                        default="",
-                        help='onnx-tensorrt repo tag.')
     parser.add_argument('--output',
                         type=str,
                         required=True,
@@ -514,13 +510,10 @@ if __name__ == '__main__':
                         type=str,
                         required=False,
                         help='Home directory for CUDNN.')
-
-    parser.add_argument(
-        '--ort-openvino',
-        type=str,
-        required=False,
-        help=
-        'Enable OpenVino execution provider using specified OpenVINO version.')
+    parser.add_argument('--ort-openvino',
+                        type=str,
+                        required=False,
+                        help='Enable OpenVino execution provider using specified OpenVINO version.')
     parser.add_argument('--ort-tensorrt',
                         action="store_true",
                         required=False,
@@ -529,6 +522,14 @@ if __name__ == '__main__':
                         type=str,
                         required=False,
                         help='Home directory for TensorRT.')
+    parser.add_argument('--onnx-tensorrt-tag',
+                        type=str,
+                        default="",
+                        help='onnx-tensorrt repo tag.')
+    parser.add_argument('--trt-version',
+                        type=str,
+                        default="",
+                        help='TRT version.')
 
     FLAGS = parser.parse_args()
     if FLAGS.enable_gpu:
@@ -536,12 +537,14 @@ if __name__ == '__main__':
 
     # if a tag is provided by the user, then simply use it
     # if the tag is empty - check whether there is an entry in the ORT_TO_TRTPARSER_VERSION_MAP
-    # map corresponding to ort version + triton container version combo. If yes then use it
+    # map corresponding to ort version + trt version combo. If yes then use it
     # otherwise we leave it empty and use the defaults from ort
     if FLAGS.onnx_tensorrt_tag == "" and FLAGS.ort_version in ORT_TO_TRTPARSER_VERSION_MAP.keys(): 
-        container_version = re.search('nvcr.io/nvidia/tritonserver:(.+?)-py3-min', FLAGS.triton_container)
-        if container_version and container_version.group(1) == ORT_TO_TRTPARSER_VERSION_MAP[FLAGS.ort_version][0]:
+        if FLAGS.trt_version == ORT_TO_TRTPARSER_VERSION_MAP[FLAGS.ort_version][0]:
             FLAGS.onnx_tensorrt_tag = ORT_TO_TRTPARSER_VERSION_MAP[FLAGS.ort_version][1]
+
+    print("*********************************************************************************")
+    print(FLAGS.onnx_tensorrt_tag)
 
 
     if target_platform() == 'windows':

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -33,9 +33,13 @@ import re
 FLAGS = None
 
 ORT_TO_TRTPARSER_VERSION_MAP = {
-    '1.9.1': (
+    '1.9.0': (
         '8.2',         # TensorRT version
-        'release/8.2-EA' # ONNX-Tensorrt parser version
+        'release/8.2-GA' # ONNX-Tensorrt parser version
+    ),
+    '1.10.0': (
+        '8.2',         # TensorRT version
+        'release/8.2-GA' # ONNX-Tensorrt parser version
     )
 }
 
@@ -540,7 +544,8 @@ if __name__ == '__main__':
     # map corresponding to ort version + trt version combo. If yes then use it
     # otherwise we leave it empty and use the defaults from ort
     if FLAGS.onnx_tensorrt_tag == "" and FLAGS.ort_version in ORT_TO_TRTPARSER_VERSION_MAP.keys(): 
-        if FLAGS.trt_version == ORT_TO_TRTPARSER_VERSION_MAP[FLAGS.ort_version][0]:
+        trt_version = re.match(r'^[0-9]+\.[0-9]+', FLAGS.trt_version)
+        if trt_version and trt_version.group(0) == ORT_TO_TRTPARSER_VERSION_MAP[FLAGS.ort_version][0]:
             FLAGS.onnx_tensorrt_tag = ORT_TO_TRTPARSER_VERSION_MAP[FLAGS.ort_version][1]
 
 

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -543,9 +543,6 @@ if __name__ == '__main__':
         if FLAGS.trt_version == ORT_TO_TRTPARSER_VERSION_MAP[FLAGS.ort_version][0]:
             FLAGS.onnx_tensorrt_tag = ORT_TO_TRTPARSER_VERSION_MAP[FLAGS.ort_version][1]
 
-    print("*********************************************************************************")
-    print(FLAGS.onnx_tensorrt_tag)
-
 
     if target_platform() == 'windows':
         # OpenVINO EP not yet supported for windows build


### PR DESCRIPTION
Triton 21.12 will include TRT 8.2. This PR is in preparation for this change.

With this change we let the user to provide a branch\tag for onnx-tensorrt parser repo "TRITON_ONNX_TENSORRT_REPO_TAG "

If this tag is specified we simply use this to build ORT. If nothing is specified then we use the defaults listed in ORT_TO_TRTPARSER_VERSION_MAP specific to the ort and trt version being built. If this map does not have an entry for the ort version and trt version combo then we simply use the default branch\tag which ort uses.

This is to enable support for versions of TRT which ORT release does not support yet. 

Note: I have tested this on linux but not windows.
