### PR TITLE
add more config options for ort

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,12 @@ optimization { execution_accelerators {
 
 ## Other Optimization Options with ONNX Runtime
 
-* `intra_op_thread_count`: Default 0 refers to number of cores.
+Details regarding when to use these options and what to expect from them can be found [here](https://onnxruntime.ai/docs/performance/tune-performance.html)
 
+* `intra_op_thread_count`: Sets the number of threads used to parallelize the execution within nodes. A value of 0 means ORT will pick a default which is number of cores.
+* `inter_op_thread_count`: Sets the number of threads used to parallelize the execution of the graph (across nodes). If sequential execution is enabled this value is ignored. 
+A value of 0 means ORT will pick a default which is number of cores.
+* `execution_mode`: Controls whether operators in the graph are executed sequentially or in parallel. Usually when the model has many branches, setting this option to 1 .i.e. "parallel" will give you better performance. Default is 0 which is "sequential execution."
 * `level`: Refers to the graph optimization level. By default all optimizations are enabled. Allowed values are -1 and 1. -1 refers to BASIC optimizations and 1 refers to basic plus extended optimizations like fusions. Please find the details [here](https://onnxruntime.ai/docs/performance/graph-optimizations.html)
 
 ```

--- a/README.md
+++ b/README.md
@@ -175,5 +175,7 @@ optimization {
 }}
 
 parameters { key: "intra_op_thread_count" value: { string_value: "0" } }
+parameters { key: "execution_mode" value: { string_value: "0" } }
+parameters { key: "inter_op_thread_count" value: { string_value: "0" } }
 
 ```

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -222,8 +222,8 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
       throw BackendModelException(TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,
           (std::string(
-               "Invalid configuration value provided. execution_mode expected "
-               "values are 0 or 1 but got " +
+               "Invalid configuration value provided. Expected values for "
+               " execution_mode are 0 or 1 but got " +
                std::to_string(execution_mode) + " .")
                .c_str())));
     } else {

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -205,7 +205,37 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
   }
   THROW_IF_BACKEND_MODEL_ORT_ERROR(
       ort_api->SetSessionGraphOptimizationLevel(soptions, optimization_level));
+
   {
+    // Controls whether you want to execute operators in your graph sequentially
+    // or in parallel. Usually when the model has many branches, setting this
+    // option to ExecutionMode::ORT_PARALLEL will give you better performance.
+    int execution_mode = 0;
+    triton::common::TritonJson::Value params;
+    if (ModelConfig().Find("parameters", &params)) {
+      THROW_IF_BACKEND_MODEL_ERROR(TryParseModelStringParameter(
+          params, "execution_mode", &execution_mode, 0));
+    }
+
+    // 0 and 1 are the only valid values.
+    if (execution_mode != 0 || execution_mode != 1) {
+      throw BackendModelException(TRITONSERVER_ErrorNew(
+          TRITONSERVER_ERROR_INVALID_ARG,
+          (std::string(
+               "Invalid configuration value provided. execution_mode expected "
+               "values are 0 or 1 but got " +
+               std::to_string(execution_mode) + " .")
+               .c_str())));
+    } else {
+      THROW_IF_BACKEND_MODEL_ORT_ERROR(ort_api->SetSessionExecutionMode(
+          soptions, execution_mode == 0 ? ExecutionMode::ORT_SEQUENTIAL
+                                        : ExecutionMode::ORT_PARALLEL));
+    }
+  }
+
+  {
+    // Sets the number of threads used to parallelize the execution within nodes
+    // A value of 0 means ORT will pick a default
     int intra_op_thread_count = 0;
     triton::common::TritonJson::Value params;
     if (ModelConfig().Find("parameters", &params)) {
@@ -215,6 +245,22 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
     if (intra_op_thread_count > 0) {
       THROW_IF_BACKEND_MODEL_ORT_ERROR(
           ort_api->SetIntraOpNumThreads(soptions, intra_op_thread_count));
+    }
+  }
+
+  {
+    // Sets the number of threads used to parallelize the execution of the graph
+    // (across nodes) If sequential execution is enabled this value is ignored
+    // A value of 0 means ORT will pick a default
+    int inter_op_thread_count = 0;
+    triton::common::TritonJson::Value params;
+    if (ModelConfig().Find("parameters", &params)) {
+      THROW_IF_BACKEND_MODEL_ERROR(TryParseModelStringParameter(
+          params, "inter_op_thread_count", &inter_op_thread_count, 0));
+    }
+    if (inter_op_thread_count > 0) {
+      THROW_IF_BACKEND_MODEL_ORT_ERROR(
+          ort_api->SetInterOpNumThreads(soptions, inter_op_thread_count));
     }
   }
 

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -218,7 +218,7 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
     }
 
     // 0 and 1 are the only valid values.
-    if (execution_mode != 0 || execution_mode != 1) {
+    if (execution_mode != 0 && execution_mode != 1) {
       throw BackendModelException(TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INVALID_ARG,
           (std::string(


### PR DESCRIPTION
Adding inter_op_num_threads and execution_mode config options. They were requested for olive + MA integration by the Olive team. 