### PR TITLE
remove version dependency on libonnxruntime.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ else()
   if (WIN32)
     set(ONNXRUNTIME_LIBRARY "onnxruntime")
   else()
-    set(ONNXRUNTIME_LIBRARY "libonnxruntime.so.${TRITON_BUILD_ONNXRUNTIME_VERSION}")
+    set(ONNXRUNTIME_LIBRARY "libonnxruntime.so")
   endif() # WIN32
   if(${TRITON_ENABLE_ONNXRUNTIME_OPENVINO})
     set(TBB_LIBRARY "libtbb.so")

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -219,10 +219,8 @@ RUN mkdir -p /opt/onnxruntime/include && \
 RUN mkdir -p /opt/onnxruntime/lib && \
     cp /workspace/build/${ONNXRUNTIME_BUILD_CONFIG}/libonnxruntime_providers_shared.so \
        /opt/onnxruntime/lib && \
-    cp /workspace/build/${ONNXRUNTIME_BUILD_CONFIG}/libonnxruntime.so.${ONNXRUNTIME_VERSION} \
-       /opt/onnxruntime/lib && \
-    (cd /opt/onnxruntime/lib && \
-     ln -sf libonnxruntime.so.${ONNXRUNTIME_VERSION} libonnxruntime.so)
+    cp /workspace/build/${ONNXRUNTIME_BUILD_CONFIG}/libonnxruntime.so \
+       /opt/onnxruntime/lib
 
 RUN mkdir -p /opt/onnxruntime/bin && \
     cp /workspace/build/${ONNXRUNTIME_BUILD_CONFIG}/onnxruntime_perf_test \

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -185,6 +185,14 @@ WORKDIR /workspace/onnxruntime
 ARG COMMON_BUILD_ARGS="--config ${ONNXRUNTIME_BUILD_CONFIG} --skip_submodule_sync --parallel --build_shared_lib --build_dir /workspace/build --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES='52;60;61;70;75;80;86' "
 '''
 
+    # Remove version info from libonnxruntime.so
+    # This makes it possible to replace ort binaries in released triton containers
+    # for experimentation, without having to build triton-ort backend.
+    df += '''
+RUN sed -i 's/VERS_%s//' tools/ci_build/gen_def.py &&  (sed -i 's/% VERSION_STRING//' tools/ci_build/gen_def.py) 
+RUN sed -i 's/set_target_properties(onnxruntime PROPERTIES VERSION ${ORT_VERSION})//' cmake/onnxruntime.cmake
+'''
+
     df += '''
 RUN ./build.sh ${{COMMON_BUILD_ARGS}} --update --build {}
 '''.format(ep_flags)


### PR DESCRIPTION
Right now libtriton_onnxruntime.so has a strict version dependency on libonnxruntime.so. This makes it difficult to replace ort binaries in released containers for easy experimentation. Current solution is to build triton-ort backend which is not always possible. 