### PR TITLE
enable global threadpool

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ optimization { execution_accelerators {
 
 Details regarding when to use these options and what to expect from them can be found [here](https://onnxruntime.ai/docs/performance/tune-performance.html)
 
+### Model Config Options
 * `intra_op_thread_count`: Sets the number of threads used to parallelize the execution within nodes. A value of 0 means ORT will pick a default which is number of cores.
 * `inter_op_thread_count`: Sets the number of threads used to parallelize the execution of the graph (across nodes). If sequential execution is enabled this value is ignored. 
 A value of 0 means ORT will pick a default which is number of cores.
@@ -178,4 +179,11 @@ parameters { key: "intra_op_thread_count" value: { string_value: "0" } }
 parameters { key: "execution_mode" value: { string_value: "0" } }
 parameters { key: "inter_op_thread_count" value: { string_value: "0" } }
 
+```
+
+### Command line options
+When intra and inter op threads is set to 0 or a value higher than 1, by default ORT creates threadpool per session. This may not be ideal in every scenario, therefore ORT also supports global threadpools. When global threadpools are enabled ORT creates 1 global threadpool which is shared by every session. Use the backend config to enable global threadpool. When global threadpool is enabled, intra and inter op num threads config should also be provided via backend config. Config values provided in model config will be ignored.
+
+```
+--backend-config=onnxruntime,enable-global-threadpool=<0,1>, --backend-config=onnxruntime,intra_op_thread_count=<int> , --backend-config=onnxruntime,inter_op_thread_count=<int> 
 ```

--- a/src/onnxruntime_loader.cc
+++ b/src/onnxruntime_loader.cc
@@ -80,7 +80,7 @@ OnnxLoader::Init(common::TritonJson::Value& backend_config)
           // default 0 which means value equal to number of cores will be used.
           RETURN_IF_ORT_ERROR(
               ort_api->CreateThreadingOptions(&threading_options));
-          if (cmdline.Find("intra-op-num-threads", &value)) {
+          if (cmdline.Find("intra_op_thread_count", &value)) {
             int intra_op_num_threads = 0;
             RETURN_IF_ERROR(value.AsString(&value_str));
             RETURN_IF_ERROR(ParseIntValue(value_str, &intra_op_num_threads));
@@ -89,7 +89,7 @@ OnnxLoader::Init(common::TritonJson::Value& backend_config)
                   threading_options, intra_op_num_threads));
             }
           }
-          if (cmdline.Find("inter-op-num-threads", &value)) {
+          if (cmdline.Find("inter_op_thread_count", &value)) {
             int inter_op_num_threads = 0;
             RETURN_IF_ERROR(value.AsString(&value_str));
             RETURN_IF_ERROR(ParseIntValue(value_str, &inter_op_num_threads));


### PR DESCRIPTION
Enabling global threadpool for ort. With this change users can choose to create global threadpool which will be shared across all the sessions. Default behavior remains the same. Depending on user scenario global threadpool can bring in perf gains. 