### PR TITLE
Fix error handling to include failed counts in infer stat

### DIFF
--- a/src/onnxruntime_utils.h
+++ b/src/onnxruntime_utils.h
@@ -38,47 +38,21 @@ namespace triton { namespace backend { namespace onnxruntime {
 
 extern const OrtApi* ort_api;
 
-#define RESPOND_ALL_AND_RETURN_IF_ERROR(                          \
-    REQUESTS, REQUEST_COUNT, RESPONSES, S)                        \
-  do {                                                            \
-    TRITONSERVER_Error* raarie_err__ = (S);                       \
-    if (raarie_err__ != nullptr) {                                \
-      for (uint32_t r = 0; r < REQUEST_COUNT; ++r) {              \
-        TRITONBACKEND_Response* response = (*RESPONSES)[r];       \
-        if (response != nullptr) {                                \
-          LOG_IF_ERROR(                                           \
-              TRITONBACKEND_ResponseSend(                         \
-                  response, TRITONSERVER_RESPONSE_COMPLETE_FINAL, \
-                  raarie_err__),                                  \
-              "failed to send ONNXRuntime backend response");     \
-          response = nullptr;                                     \
-        }                                                         \
-        LOG_IF_ERROR(                                             \
-            TRITONBACKEND_RequestRelease(                         \
-                REQUESTS[r], TRITONSERVER_REQUEST_RELEASE_ALL),   \
-            "failed releasing request");                          \
-        REQUESTS[r] = nullptr;                                    \
-      }                                                           \
-      TRITONSERVER_ErrorDelete(raarie_err__);                     \
-      return;                                                     \
-    }                                                             \
-  } while (false) 
-
-#define RESPOND_ALL_AND_RETURN_IF_ORT_ERROR(                                      \
-    REQUESTS, REQUEST_COUNT, RESPONSES, S)                                        \
-  do {                                                                            \
-    OrtStatus* status__ = (S);                                                    \
-    if (status__ != nullptr) {                                                    \
-      OrtErrorCode code = ort_api->GetErrorCode(status__);                        \
-      std::string msg = std::string(ort_api->GetErrorMessage(status__));          \
-      ort_api->ReleaseStatus(status__);                                           \
-      auto err__ = TRITONSERVER_ErrorNew(                                         \
-              TRITONSERVER_ERROR_INTERNAL,                                        \
-              (std::string("onnx runtime error ") + std::to_string(code) +        \
-               ": " + msg)                                                        \
-                  .c_str());                                                      \
-      RESPOND_ALL_AND_RETURN_IF_ERROR(REQUESTS, REQUEST_COUNT, RESPONSES, err__); \
-    }                                                                             \
+#define RESPOND_ALL_AND_SET_TRUE_IF_ORT_ERROR(                               \
+    RESPONSES, RESPONSES_COUNT, BOOL, S)                                     \
+  do {                                                                       \
+    OrtStatus* status__ = (S);                                               \
+    if (status__ != nullptr) {                                               \
+      OrtErrorCode code = ort_api->GetErrorCode(status__);                   \
+      std::string msg = std::string(ort_api->GetErrorMessage(status__));     \
+      ort_api->ReleaseStatus(status__);                                      \
+      auto err__ = TRITONSERVER_ErrorNew(                                    \
+          TRITONSERVER_ERROR_INTERNAL, (std::string("onnx runtime error ") + \
+                                        std::to_string(code) + ": " + msg)   \
+                                           .c_str());                        \
+      RESPOND_ALL_AND_SET_TRUE_IF_ERROR(                                     \
+          RESPONSES, RESPONSES_COUNT, BOOL, err__);                          \
+    }                                                                        \
   } while (false)
 
 #define RETURN_IF_ORT_ERROR(S)                                               \
@@ -93,7 +67,7 @@ extern const OrtApi* ort_api;
                                         std::to_string(code) + ": " + msg)   \
                                            .c_str());                        \
     }                                                                        \
-  } while (false)                    
+  } while (false)
 
 #define THROW_IF_BACKEND_MODEL_ORT_ERROR(S)                                  \
   do {                                                                       \


### PR DESCRIPTION
Uses a macro form the common backend repo added by this [PR](https://github.com/triton-inference-server/backend/pull/51).

Note: The fail count being reported correctly with the fix.
###After:
```
curl localhost:8000/v2/models/stats
{"model_stats":[{"name":"onnx_float32_float32_float32","version":"1","last_inference":0,"inference_count":0,"execution_count":0,"inference_stats":{"success":{"count":0,"ns":0},"fail":{"count":1,"ns":2919154},"queue":{"count":0,"ns":0},"compute_input":{"count":0,"ns":0},"compute_infer":{"count":0,"ns":0},"compute_output":{"count":0,"ns":0}},"batch_stats":[]}]}
```
###Before:
```
curl localhost:8000/v2/models/stats
{"model_stats":[{"name":"onnx_float32_float32_float32","version":"1","last_inference":0,"inference_count":0,"execution_count":0,"inference_stats":{"success":{"count":0,"ns":0},"fail":{"count":0,"ns":0},"queue":{"count":0,"ns":0},"compute_input":{"count":0,"ns":0},"compute_infer":{"count":0,"ns":0},"compute_output":{"count":0,"ns":0}},"batch_stats":[]}]}
```