### PR TITLE
libonnx_proto.so is needed for OV 2021.4 for onnx OV execution

### DIFF
--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2020-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -271,6 +271,12 @@ RUN cp -r /opt/intel/openvino_${ONNXRUNTIME_OPENVINO_VERSION}/licensing \
 
 RUN cp /workspace/onnxruntime/include/onnxruntime/core/providers/openvino/openvino_provider_factory.h \
        /opt/onnxruntime/include
+
+# libonnx_proto.so is needed when openvino execution provider is used
+RUN if [ -f /opt/intel/openvino_${ONNXRUNTIME_OPENVINO_VERSION}/deployment_tools/ngraph/lib/libonnx_proto.so ]; then \
+        cp /opt/intel/openvino_${ONNXRUNTIME_OPENVINO_VERSION}/deployment_tools/ngraph/lib/libonnx_proto.so \
+        /opt/onnxruntime/lib; \
+    fi
 
 RUN cp /workspace/build/${ONNXRUNTIME_BUILD_CONFIG}/libonnxruntime_providers_openvino.so \
        /opt/onnxruntime/lib && \

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -301,6 +301,10 @@ RUN cp /workspace/build/${ONNXRUNTIME_BUILD_CONFIG}/libonnxruntime_providers_ope
        /opt/onnxruntime/lib && \
     cp /opt/intel/openvino_${ONNXRUNTIME_OPENVINO_VERSION}/deployment_tools/inference_engine/lib/intel64/libinference_engine_lp_transformations.so \
        /opt/onnxruntime/lib && \
+    cp /opt/intel/openvino_${ONNXRUNTIME_OPENVINO_VERSION}/deployment_tools/inference_engine/lib/intel64/libinference_engine_ir_reader.so \
+       /opt/onnxruntime/lib && \
+    cp /opt/intel/openvino_${ONNXRUNTIME_OPENVINO_VERSION}/deployment_tools/inference_engine/lib/intel64/libinference_engine_onnx_reader.so \
+       /opt/onnxruntime/lib && \
     (cd /opt/onnxruntime/lib && \
      chmod a-x * && \
      ln -sf libtbb.so.2 libtbb.so)

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -272,10 +272,13 @@ RUN cp -r /opt/intel/openvino_${ONNXRUNTIME_OPENVINO_VERSION}/licensing \
 RUN cp /workspace/onnxruntime/include/onnxruntime/core/providers/openvino/openvino_provider_factory.h \
        /opt/onnxruntime/include
 
-# libonnx_proto.so is needed when openvino execution provider is used
+# libonnx_proto.so, libprotobuf.so.3.7.1.0 are needed when openvino execution provider is used
 RUN if [ -f /opt/intel/openvino_${ONNXRUNTIME_OPENVINO_VERSION}/deployment_tools/ngraph/lib/libonnx_proto.so ]; then \
         cp /opt/intel/openvino_${ONNXRUNTIME_OPENVINO_VERSION}/deployment_tools/ngraph/lib/libonnx_proto.so \
-        /opt/onnxruntime/lib; \
+            /opt/onnxruntime/lib; \
+        cp /opt/intel/openvino_${ONNXRUNTIME_OPENVINO_VERSION}/deployment_tools/ngraph/lib/libprotobuf.so.3.7.1.0 \
+            /opt/onnxruntime/lib; \
+        (cd /opt/onnxruntime/lib && ln -sf libprotobuf.so.3.7.1.0 libprotobuf.so); \
     fi
 
 RUN cp /workspace/build/${ONNXRUNTIME_BUILD_CONFIG}/libonnxruntime_providers_openvino.so \


### PR DESCRIPTION
After adding in libonnx_proto.so and the corr libprotobufs.so files ORT throws the error

```
model_repository_manager.cc:1155] failed to load 'resnet50_cpu_openvino' version 1: Internal: onnx runtime error 6: Exception during initialization: /workspace/onnxruntime/onnxruntime/core/providers/openvino/backend_utils.cc:143 std::shared_ptr<InferenceEngine::CNNNetwork> onnxruntime::openvino_ep::backend_utils::CreateCNNNetwork(const onnx::ModelProto&, const onnxruntime::openvino_ep::GlobalContext&, const onnxruntime::openvino_ep::SubGraphContext&, std::map<std::__cxx11::basic_string<char>, std::shared_ptr<ngraph::Node> >&) [OpenVINO-EP] [OpenVINO-EP] Exception while Reading network: Unknown model format! Cannot find reader for the model and read it. Please check that reader library exists in your PATH.
```

The model is a resnet50 `.onnx` model.

Adding in libinference_engine_ir_reader.so and libinference_engine_onnx_reader.so does not help. 

@askhade would you be able to help me understand what is missing here. This issue is occurring because I am moving from using OpenVino 2021.2 to 2021.4

cc @tanmayv25