### PR TITLE
Fix L0_infer_cudashm failure

### DIFF
--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -1547,9 +1547,6 @@ ModelInstanceState::ProcessRequests(
     if (Kind() == TRITONSERVER_INSTANCEGROUPKIND_GPU) {
       preferred_memory_type = TRITONSERVER_MEMORY_GPU;
       preferred_memory_type_id = DeviceId();
-    } else {
-      preferred_memory_type = TRITONSERVER_MEMORY_CPU;
-      preferred_memory_type_id = 0;
     }
 
     // Request to retrieve all model outputs. 'output_names' and
@@ -1601,8 +1598,8 @@ ModelInstanceState::ProcessRequests(
           }
         }
 
-        // If the instance type is not KIND_GPU, set the memory type to CPU.
-        if (Kind() != TRITONSERVER_INSTANCEGROUPKIND_GPU) {
+        // If the cuda allocator is not set, bind the output to CPU.
+        if (cuda_allocator_info_ == nullptr) {
           memory_type = TRITONSERVER_MEMORY_CPU;
           memory_type_id = 0;
         }

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -1547,6 +1547,9 @@ ModelInstanceState::ProcessRequests(
     if (Kind() == TRITONSERVER_INSTANCEGROUPKIND_GPU) {
       preferred_memory_type = TRITONSERVER_MEMORY_GPU;
       preferred_memory_type_id = DeviceId();
+    } else {
+      preferred_memory_type = TRITONSERVER_MEMORY_CPU;
+      preferred_memory_type_id = 0;
     }
 
     // Request to retrieve all model outputs. 'output_names' and
@@ -1576,8 +1579,7 @@ ModelInstanceState::ProcessRequests(
                    .c_str()));
         } else if (iit->second.type_ != ONNX_TENSOR_ELEMENT_DATA_TYPE_STRING) {
           // Query the memory type of destination output buffer. Bind the
-          // output
-          // to this destination memory type. The destination memory type
+          // output to this destination memory type. The destination memory type
           // for an output for all requests should be same. So use any request
           // for this query.
           memory_type = preferred_memory_type;
@@ -1598,6 +1600,13 @@ ModelInstanceState::ProcessRequests(
             memory_type_id = 0;
           }
         }
+
+        // If the instance type is not KIND_GPU, set the memory type to CPU.
+        if (Kind() != TRITONSERVER_INSTANCEGROUPKIND_GPU) {
+          memory_type = TRITONSERVER_MEMORY_CPU;
+          memory_type_id = 0;
+        }
+
         // finally save the derived mem type and device id as we need it for
         // reading the outputs.
         output_device_info_.insert(
@@ -1775,13 +1784,12 @@ ModelInstanceState::SetInputTensors(
       std::vector<std::pair<TRITONSERVER_MemoryType, int64_t>>
           allowed_input_types;
       if (Kind() == TRITONSERVER_INSTANCEGROUPKIND_GPU) {
-        allowed_input_types = {
-            {TRITONSERVER_MEMORY_GPU, DeviceId()},
-            {TRITONSERVER_MEMORY_CPU_PINNED, 0},
-            {TRITONSERVER_MEMORY_CPU, 0}};
+        allowed_input_types = {{TRITONSERVER_MEMORY_GPU, DeviceId()},
+                               {TRITONSERVER_MEMORY_CPU_PINNED, 0},
+                               {TRITONSERVER_MEMORY_CPU, 0}};
       } else {
-        allowed_input_types = {
-            {TRITONSERVER_MEMORY_CPU_PINNED, 0}, {TRITONSERVER_MEMORY_CPU, 0}};
+        allowed_input_types = {{TRITONSERVER_MEMORY_CPU_PINNED, 0},
+                               {TRITONSERVER_MEMORY_CPU, 0}};
       }
 
       RETURN_IF_ERROR(collector->ProcessTensor(


### PR DESCRIPTION
The root cause for the segfault was that when instance kind is KIND_CPU and the OutputBufferQuery returns a GPU memory, `cuda_allocator_info_` is a nullptr and will lead to a segfault. Stacktrace of the segfault:

```
#1  0x00007f8338fa44d9 in triton::backend::onnxruntime::ModelInstanceState::ProcessRequests (this=0x7f80d80115c0, requests=0x7f81580440c0, request_count=1) at /workspace/onnxruntime_backend/src/onnxruntime.cc:1630
#2  0x00007f8338fb10c6 in triton::backend::onnxruntime::TRITONBACKEND_ModelInstanceExecute (instance=0x7f80d8015c30, requests=0x7f81580440c0, request_count=1) at /workspace/onnxruntime_backend/src/onnxruntime.cc:2600
```