### PR TITLE
Fix OrtEnv creation causing server to hang during shutdown.

### DIFF
--- a/src/onnxruntime_loader.cc
+++ b/src/onnxruntime_loader.cc
@@ -31,6 +31,7 @@
 #include <locale>
 #include <string>
 #include <thread>
+
 #include "onnxruntime_utils.h"
 
 namespace triton { namespace backend { namespace onnxruntime {
@@ -55,9 +56,9 @@ OnnxLoader::Init(common::TritonJson::Value& backend_config)
     OrtLoggingLevel logging_level =
         TRITONSERVER_LogIsEnabled(TRITONSERVER_LOG_VERBOSE)
             ? ORT_LOGGING_LEVEL_VERBOSE
-            : TRITONSERVER_LogIsEnabled(TRITONSERVER_LOG_WARN)
-                  ? ORT_LOGGING_LEVEL_WARNING
-                  : ORT_LOGGING_LEVEL_ERROR;
+        : TRITONSERVER_LogIsEnabled(TRITONSERVER_LOG_WARN)
+            ? ORT_LOGGING_LEVEL_WARNING
+            : ORT_LOGGING_LEVEL_ERROR;
 
     // Controls whether to enable global threadpool which will be shared across
     // sessions. Use this in conjunction with DisablePerSessionThreads API or
@@ -110,7 +111,6 @@ OnnxLoader::Init(common::TritonJson::Value& backend_config)
       status = ort_api->CreateEnv(logging_level, "log", &env);
     }
 
-    status = ort_api->CreateEnv(logging_level, "log", &env);
     loader.reset(new OnnxLoader(env, global_threadpool_enabled));
     RETURN_IF_ORT_ERROR(status);
   } else {


### PR DESCRIPTION
OrtEnv gets created twice in onnx_loader. This causes its refcount to
increase to 2. Due to this when ReleaseEnv is called inside ~OnnxLoader,
it does nothing other than decrease the refcount to 1. Next when all the libraries
are unloaded the [openvino global context ptr](https://github.com/microsoft/onnxruntime/blob/master/onnxruntime/core/providers/openvino/backend_manager.cc#L16) gets unloaded first followed by OrtEnv's
destructor which now actually does useful work trying to delete the openvno ctx ptr
which is not valid any more causing memory corruption.