### PR TITLE
Fixes tensorrt cache being regenerated on path change

### DIFF
--- a/src/onnxruntime_loader.cc
+++ b/src/onnxruntime_loader.cc
@@ -31,6 +31,7 @@
 #include <locale>
 #include <string>
 #include <thread>
+#include <fstream>
 
 #include "onnxruntime_utils.h"
 
@@ -191,8 +192,13 @@ OnnxLoader::LoadSession(
           loader->env_, ort_style_model_str.c_str(), model.size(),
           session_options, session);
     } else {
-      status = ort_api->CreateSession(
-          loader->env_, ort_style_model_str.c_str(), session_options, session);
+      std::ifstream bytes_stream(ort_style_model_str.c_str(), std::ios::in | std::ios::binary | std::ios::ate);
+      std::streamsize num_bytes = bytes_stream.tellg();
+      bytes_stream.seekg(0, std::ios::beg);
+      std::vector<char> buffer(num_bytes);
+      bytes_stream.read(buffer.data(), num_bytes);
+      status = ort_api->CreateSessionFromArray(
+          loader->env_, buffer.data(), num_bytes, session_options, session);
     }
 
     if (status != nullptr) {

--- a/src/onnxruntime_loader.cc
+++ b/src/onnxruntime_loader.cc
@@ -192,6 +192,10 @@ OnnxLoader::LoadSession(
           loader->env_, ort_style_model_str.c_str(), model.size(),
           session_options, session);
     } else {
+      // Onnxruntime uses the model path to create the TRT hash path,
+      // this triggers a regeneration when coupled with temporal paths
+      // Using the binary directly sidesteps the issue
+      // see: https://github.com/microsoft/onnxruntime/blob/927bac0/onnxruntime/core/framework/execution_provider.cc#L151
       std::ifstream bytes_stream(ort_style_model_str.c_str(), std::ios::in | std::ios::binary | std::ios::ate);
       std::streamsize num_bytes = bytes_stream.tellg();
       bytes_stream.seekg(0, std::ios::beg);


### PR DESCRIPTION
Onnxruntime uses the path as a hash for the tensorrt cache, passing a binary avoids this and works as intended.

Fixes https://github.com/triton-inference-server/server/issues/4587