### PR TITLE
Support initializer as inference request input - onnxruntime backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ include(FetchContent)
 
 FetchContent_Declare(
   repo-common
-  GIT_REPOSITORY https://github.com/taoisu/triton-inference-server-common.git
+  GIT_REPOSITORY https://github.com/triton-inference-server/common.git
   GIT_TAG ${TRITON_COMMON_REPO_TAG}
   GIT_SHALLOW ON
 )
@@ -185,7 +185,7 @@ FetchContent_Declare(
 )
 FetchContent_Declare(
   repo-backend
-  GIT_REPOSITORY https://github.com/taoisu/triton-inference-server-backend.git
+  GIT_REPOSITORY https://github.com/triton-inference-server/backend.git
   GIT_TAG ${TRITON_BACKEND_REPO_TAG}
   GIT_SHALLOW ON
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,19 +173,19 @@ include(FetchContent)
 
 FetchContent_Declare(
   repo-common
-  GIT_REPOSITORY https://github.com/triton-inference-server/common.git
+  GIT_REPOSITORY https://github.com/taoisu/triton-inference-server-common.git
   GIT_TAG ${TRITON_COMMON_REPO_TAG}
   GIT_SHALLOW ON
 )
 FetchContent_Declare(
   repo-core
-  GIT_REPOSITORY https://github.com/triton-inference-server/core.git
+  GIT_REPOSITORY https://github.com/taoisu/triton-inference-server-core.git
   GIT_TAG ${TRITON_CORE_REPO_TAG}
   GIT_SHALLOW ON
 )
 FetchContent_Declare(
   repo-backend
-  GIT_REPOSITORY https://github.com/triton-inference-server/backend.git
+  GIT_REPOSITORY https://github.com/taoisu/triton-inference-server-backend.git
   GIT_TAG ${TRITON_BACKEND_REPO_TAG}
   GIT_SHALLOW ON
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,7 +179,7 @@ FetchContent_Declare(
 )
 FetchContent_Declare(
   repo-core
-  GIT_REPOSITORY https://github.com/taoisu/triton-inference-server-core.git
+  GIT_REPOSITORY https://github.com/triton-inference-server/core.git
   GIT_TAG ${TRITON_CORE_REPO_TAG}
   GIT_SHALLOW ON
 )

--- a/src/onnxruntime_utils.cc
+++ b/src/onnxruntime_utils.cc
@@ -54,17 +54,25 @@ OnnxTypeName(ONNXType onnx_type)
   return "ONNX_TYPE_UNKNOWN";
 }
 
+enum class NameType {
+  INPUT,
+  OUTPUT,
+  INITIALIZER,
+};
+
 TRITONSERVER_Error*
-InputOutputNames(
-    OrtSession* session, bool is_input, std::set<std::string>& names)
+InputOutputInitializerNames(
+    OrtSession* session, NameType type, std::set<std::string>& names)
 {
   names.clear();
 
   size_t num_nodes;
-  if (is_input) {
+  if (type == NameType::INPUT) {
     RETURN_IF_ORT_ERROR(ort_api->SessionGetInputCount(session, &num_nodes));
-  } else {
+  } else if (type == NameType::OUTPUT) {
     RETURN_IF_ORT_ERROR(ort_api->SessionGetOutputCount(session, &num_nodes));
+  } else {
+    RETURN_IF_ORT_ERROR(ort_api->SessionGetOverridableInitializerCount(session, &num_nodes));
   }
 
   // iterate over all input / output nodes
@@ -73,12 +81,12 @@ InputOutputNames(
   OrtStatus* onnx_status = nullptr;
   for (size_t i = 0; i < num_nodes; i++) {
     char* node_name = nullptr;
-    if (is_input) {
-      onnx_status =
-          ort_api->SessionGetInputName(session, i, allocator, &node_name);
+    if (type == NameType::INPUT) {
+      onnx_status = ort_api->SessionGetInputName(session, i, allocator, &node_name);
+    } else if (type == NameType::OUTPUT) {
+      onnx_status = ort_api->SessionGetOutputName(session, i, allocator, &node_name);
     } else {
-      onnx_status =
-          ort_api->SessionGetOutputName(session, i, allocator, &node_name);
+      onnx_status = ort_api->SessionGetOverridableInitializerName(session, i, allocator, &node_name);
     }
 
     // Make a std::string copy of the name and then free 'node_name'
@@ -107,28 +115,33 @@ InputOutputNames(
 }
 
 TRITONSERVER_Error*
-InputOutputInfos(
-    OrtSession* session, OrtAllocator* allocator, bool is_input,
+InputOutputInitializerInfos(
+    OrtSession* session, OrtAllocator* allocator, NameType type,
     OnnxTensorInfoMap& infos)
 {
   infos.clear();
 
   size_t num_nodes;
-  if (is_input) {
+  if (type == NameType::INPUT) {
     RETURN_IF_ORT_ERROR(ort_api->SessionGetInputCount(session, &num_nodes));
-  } else {
+  } else if (type == NameType::OUTPUT) {
     RETURN_IF_ORT_ERROR(ort_api->SessionGetOutputCount(session, &num_nodes));
+  } else {
+    RETURN_IF_ORT_ERROR(ort_api->SessionGetOverridableInitializerCount(session, &num_nodes));
   }
 
   // iterate over all nodes
   for (size_t i = 0; i < num_nodes; i++) {
     char* cname = nullptr;
-    if (is_input) {
+    if (type == NameType::INPUT) {
       RETURN_IF_ORT_ERROR(
           ort_api->SessionGetInputName(session, i, allocator, &cname));
-    } else {
+    } else if (type == NameType::OUTPUT) {
       RETURN_IF_ORT_ERROR(
           ort_api->SessionGetOutputName(session, i, allocator, &cname));
+    } else {
+      RETURN_IF_ORT_ERROR(
+          ort_api->SessionGetOverridableInitializerName(session, i, allocator, &cname));
     }
 
     // Make a std::string copy of the name and then free 'cname' since
@@ -146,12 +159,15 @@ InputOutputInfos(
     }
 
     OrtTypeInfo* typeinfo;
-    if (is_input) {
+    if (type == NameType::INPUT) {
       RETURN_IF_ORT_ERROR(
           ort_api->SessionGetInputTypeInfo(session, i, &typeinfo));
-    } else {
+    } else if (type == NameType::OUTPUT) {
       RETURN_IF_ORT_ERROR(
           ort_api->SessionGetOutputTypeInfo(session, i, &typeinfo));
+    } else {
+      RETURN_IF_ORT_ERROR(
+          ort_api->SessionGetOverridableInitializerTypeInfo(session, i, &typeinfo));
     }
 
     std::unique_ptr<OrtTypeInfo, TypeInfoDeleter> typeinfo_wrapper(typeinfo);
@@ -398,29 +414,43 @@ OnnxDataTypeToModelConfigDataType(ONNXTensorElementDataType data_type)
 }
 
 TRITONSERVER_Error*
+OverridableInitializerNames(OrtSession* session, std::set<std::string>& names)
+{
+  return InputOutputInitializerNames(session, NameType::INITIALIZER, names);
+}
+
+TRITONSERVER_Error*
 InputNames(OrtSession* session, std::set<std::string>& names)
 {
-  return InputOutputNames(session, true, names);
+  return InputOutputInitializerNames(session, NameType::INPUT, names);
 }
 
 TRITONSERVER_Error*
 OutputNames(OrtSession* session, std::set<std::string>& names)
 {
-  return InputOutputNames(session, false, names);
+  return InputOutputInitializerNames(session, NameType::OUTPUT, names);
 }
 
 TRITONSERVER_Error*
 InputInfos(
     OrtSession* session, OrtAllocator* allocator, OnnxTensorInfoMap& infos)
 {
-  return InputOutputInfos(session, allocator, true, infos);
+  return InputOutputInitializerInfos(session, allocator, NameType::INPUT, infos);
 }
 
 TRITONSERVER_Error*
 OutputInfos(
     OrtSession* session, OrtAllocator* allocator, OnnxTensorInfoMap& infos)
 {
-  return InputOutputInfos(session, allocator, false, infos);
+  return InputOutputInitializerInfos(session, allocator, NameType::OUTPUT, infos);
+}
+
+TRITONSERVER_Error*
+OverridableInitializerInfos(
+    OrtSession* session, OrtAllocator* allocator, OnnxTensorInfoMap& infos)
+{
+  return InputOutputInitializerInfos(
+      session, allocator, NameType::INITIALIZER, infos);
 }
 
 TRITONSERVER_Error*

--- a/src/onnxruntime_utils.cc
+++ b/src/onnxruntime_utils.cc
@@ -67,12 +67,16 @@ InputOutputInitializerNames(
   names.clear();
 
   size_t num_nodes;
-  if (type == NameType::INPUT) {
-    RETURN_IF_ORT_ERROR(ort_api->SessionGetInputCount(session, &num_nodes));
-  } else if (type == NameType::OUTPUT) {
-    RETURN_IF_ORT_ERROR(ort_api->SessionGetOutputCount(session, &num_nodes));
-  } else {
-    RETURN_IF_ORT_ERROR(ort_api->SessionGetOverridableInitializerCount(session, &num_nodes));
+  switch (type) {
+    case NameType::INPUT:
+      RETURN_IF_ORT_ERROR(ort_api->SessionGetInputCount(session, &num_nodes));
+      break;
+    case NameType::OUTPUT:
+      RETURN_IF_ORT_ERROR(ort_api->SessionGetOutputCount(session, &num_nodes));
+      break;
+    case NameType::INITIALIZER:
+      RETURN_IF_ORT_ERROR(ort_api->SessionGetOverridableInitializerCount(session, &num_nodes));
+      break;
   }
 
   // iterate over all input / output nodes
@@ -81,12 +85,16 @@ InputOutputInitializerNames(
   OrtStatus* onnx_status = nullptr;
   for (size_t i = 0; i < num_nodes; i++) {
     char* node_name = nullptr;
-    if (type == NameType::INPUT) {
-      onnx_status = ort_api->SessionGetInputName(session, i, allocator, &node_name);
-    } else if (type == NameType::OUTPUT) {
-      onnx_status = ort_api->SessionGetOutputName(session, i, allocator, &node_name);
-    } else {
-      onnx_status = ort_api->SessionGetOverridableInitializerName(session, i, allocator, &node_name);
+    switch (type) {
+      case NameType::INPUT:
+        onnx_status = ort_api->SessionGetInputName(session, i, allocator, &node_name);
+        break;
+      case NameType::OUTPUT:
+        onnx_status = ort_api->SessionGetOutputName(session, i, allocator, &node_name);
+        break;
+      case NameType::INITIALIZER:
+        onnx_status = ort_api->SessionGetOverridableInitializerName(session, i, allocator, &node_name);
+        break;
     }
 
     // Make a std::string copy of the name and then free 'node_name'
@@ -122,26 +130,34 @@ InputOutputInitializerInfos(
   infos.clear();
 
   size_t num_nodes;
-  if (type == NameType::INPUT) {
-    RETURN_IF_ORT_ERROR(ort_api->SessionGetInputCount(session, &num_nodes));
-  } else if (type == NameType::OUTPUT) {
-    RETURN_IF_ORT_ERROR(ort_api->SessionGetOutputCount(session, &num_nodes));
-  } else {
-    RETURN_IF_ORT_ERROR(ort_api->SessionGetOverridableInitializerCount(session, &num_nodes));
+  switch (type) {
+    case NameType::INPUT:
+      RETURN_IF_ORT_ERROR(ort_api->SessionGetInputCount(session, &num_nodes));
+      break;
+    case NameType::OUTPUT:
+      RETURN_IF_ORT_ERROR(ort_api->SessionGetOutputCount(session, &num_nodes));
+      break;
+    case NameType::INITIALIZER:
+      RETURN_IF_ORT_ERROR(ort_api->SessionGetOverridableInitializerCount(session, &num_nodes));
+      break;
   }
 
   // iterate over all nodes
   for (size_t i = 0; i < num_nodes; i++) {
     char* cname = nullptr;
-    if (type == NameType::INPUT) {
-      RETURN_IF_ORT_ERROR(
+    switch (type) {
+      case NameType::INPUT:
+        RETURN_IF_ORT_ERROR(
           ort_api->SessionGetInputName(session, i, allocator, &cname));
-    } else if (type == NameType::OUTPUT) {
-      RETURN_IF_ORT_ERROR(
+        break;
+      case NameType::OUTPUT:
+        RETURN_IF_ORT_ERROR(
           ort_api->SessionGetOutputName(session, i, allocator, &cname));
-    } else {
-      RETURN_IF_ORT_ERROR(
+        break;
+      case NameType::INITIALIZER:
+        RETURN_IF_ORT_ERROR(
           ort_api->SessionGetOverridableInitializerName(session, i, allocator, &cname));
+        break;
     }
 
     // Make a std::string copy of the name and then free 'cname' since
@@ -159,15 +175,19 @@ InputOutputInitializerInfos(
     }
 
     OrtTypeInfo* typeinfo;
-    if (type == NameType::INPUT) {
-      RETURN_IF_ORT_ERROR(
-          ort_api->SessionGetInputTypeInfo(session, i, &typeinfo));
-    } else if (type == NameType::OUTPUT) {
-      RETURN_IF_ORT_ERROR(
-          ort_api->SessionGetOutputTypeInfo(session, i, &typeinfo));
-    } else {
-      RETURN_IF_ORT_ERROR(
-          ort_api->SessionGetOverridableInitializerTypeInfo(session, i, &typeinfo));
+    switch (type) {
+      case NameType::INPUT:
+        RETURN_IF_ORT_ERROR(
+            ort_api->SessionGetInputTypeInfo(session, i, &typeinfo));
+        break;
+      case NameType::OUTPUT:
+        RETURN_IF_ORT_ERROR(
+            ort_api->SessionGetOutputTypeInfo(session, i, &typeinfo));
+        break;
+      case NameType::INITIALIZER:
+        RETURN_IF_ORT_ERROR(
+            ort_api->SessionGetOverridableInitializerTypeInfo(session, i, &typeinfo));
+        break;
     }
 
     std::unique_ptr<OrtTypeInfo, TypeInfoDeleter> typeinfo_wrapper(typeinfo);

--- a/src/onnxruntime_utils.h
+++ b/src/onnxruntime_utils.h
@@ -134,11 +134,15 @@ ONNXTensorElementDataType ModelConfigDataTypeToOnnxDataType(
 std::string OnnxDataTypeToModelConfigDataType(
     ONNXTensorElementDataType data_type);
 
+TRITONSERVER_Error* OverridableInitializerNames(
+    OrtSession* session, std::set<std::string>& names);
 TRITONSERVER_Error* InputNames(
     OrtSession* session, std::set<std::string>& names);
 TRITONSERVER_Error* OutputNames(
     OrtSession* session, std::set<std::string>& names);
 
+TRITONSERVER_Error* OverridableInitializerInfos(
+    OrtSession* session, OrtAllocator* allocator, OnnxTensorInfoMap& infos);
 TRITONSERVER_Error* InputInfos(
     OrtSession* session, OrtAllocator* allocator, OnnxTensorInfoMap& infos);
 TRITONSERVER_Error* OutputInfos(


### PR DESCRIPTION
Background of this PR can be found here: https://github.com/triton-inference-server/server/issues/5489

Essentially, in onnxruntime, initializers (model weights) can be specified as input to override the default weights. The initializers are different in the sense they don't have batch dimension, so changes need to be made in this repo to make sure the shape treatment is correct. In addition, because model weights will be overridden, dynamic batching should be disabled when initializers are to be fed.