### PR TITLE
Remove the cherry-pick fix

### DIFF
--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -187,11 +187,8 @@ RUN wget ${INTEL_COMPUTE_RUNTIME_URL}/intel-gmmlib_19.3.2_amd64.deb && \
     ARG ONNXRUNTIME_REPO
     ARG ONNXRUNTIME_BUILD_CONFIG
 
-    # [FIXME] WAR to cherry pick "extra include" fix to build with CUDA 12,
-    # should be removed once advance to an ORT release that contains the fix.
     RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime && \
-        (cd onnxruntime && git submodule update --init --recursive && \
-         git cherry-pick -n 12d91173c4478e0975771c06fd9d062a33c46339)
+        (cd onnxruntime && git submodule update --init --recursive)
 
         '''
 


### PR DESCRIPTION
The fix is available in ORT 1.14.1 release which we are using.
https://github.com/microsoft/onnxruntime/blob/v1.14.1/onnxruntime/contrib_ops/cuda/bert/attention_impl.cu#L31