### PR TITLE
Include compute_90 architecture build on Jetson

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,9 +81,6 @@ project(tritononnxruntimebackend LANGUAGES C CXX)
 #   - If you want to disable GPU usage, set TRITON_ENABLE_GPU=OFF. 
 #    This will make builds with CUDA and TensorRT flags to fail. 
 #
-#   - If you want to optionally set the platform rather than rely on it being detected,
-#     set TRITON_BUILD_PLATFORM equal to Ubuntu, Windows, or Jetpack.
-#
 option(TRITON_ENABLE_GPU "Enable GPU support in backend" ON)
 option(TRITON_ENABLE_STATS "Include statistics collections in backend" ON)
 option(TRITON_ENABLE_ONNXRUNTIME_TENSORRT
@@ -97,7 +94,6 @@ set(TRITON_BUILD_ONNXRUNTIME_OPENVINO_VERSION "" CACHE STRING "ONNXRuntime OpenV
 set(TRITON_BUILD_CUDA_VERSION "" CACHE STRING "Version of CUDA install")
 set(TRITON_BUILD_CUDA_HOME "" CACHE PATH "Path to CUDA install")
 set(TRITON_BUILD_CUDNN_HOME "" CACHE PATH "Path to CUDNN install")
-set(TRITON_BUILD_PLATFORM "" CACHE STRING "Platform of build")
 set(TRITON_BUILD_TENSORRT_HOME "" CACHE PATH "Path to TensorRT install")
 set(TRITON_ONNXRUNTIME_INCLUDE_PATHS "" CACHE PATH "Paths to ONNXRuntime includes")
 set(TRITON_ONNX_TENSORRT_REPO_TAG "" CACHE STRING "Tag for onnx-tensorrt repo")
@@ -338,9 +334,6 @@ if(TRITON_ONNXRUNTIME_DOCKER_BUILD)
   if(${TRITON_ENABLE_ONNXRUNTIME_OPENVINO})
     set(_GEN_FLAGS ${_GEN_FLAGS} "--ort-openvino=${TRITON_BUILD_ONNXRUNTIME_OPENVINO_VERSION}")
   endif() # TRITON_ENABLE_ONNXRUNTIME_OPENVINO
-  if(NOT ${TRITON_BUILD_PLATFORM} STREQUAL "")
-    set(_GEN_FLAGS ${_GEN_FLAGS} "--target-platform=${TRITON_BUILD_PLATFORM}")
-  endif() # TRITON_BUILD_PLATFORM
 
   set(ENABLE_GPU_EXTRA_ARGS "")
   if(${TRITON_ENABLE_GPU})

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -49,6 +49,7 @@ def target_platform():
         return FLAGS.target_platform
     return platform.system().lower()
 
+
 def dockerfile_common():
     df = '''
 ARG BASE_IMAGE={}
@@ -210,7 +211,7 @@ RUN wget ${INTEL_COMPUTE_RUNTIME_URL}/intel-gmmlib_19.3.2_amd64.deb && \
             ep_flags += ' --cudnn_home "{}"'.format(FLAGS.cudnn_home)
         if FLAGS.ort_tensorrt:
             ep_flags += ' --use_tensorrt'
-            if FLAGS.ort_version == "1.12.1" or FLAGS.ort_version == "1.13.0" or FLAGS.ort_version == "1.13.1" or  FLAGS.ort_version == "1.14.1" :
+            if FLAGS.ort_version == "1.12.1" or FLAGS.ort_version == "1.13.0" or FLAGS.ort_version == "1.13.1" or FLAGS.ort_version == "1.14.1":
                 ep_flags += ' --use_tensorrt_builtin_parser'
             if FLAGS.tensorrt_home is not None:
                 ep_flags += ' --tensorrt_home "{}"'.format(FLAGS.tensorrt_home)

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -220,7 +220,7 @@ RUN wget ${INTEL_COMPUTE_RUNTIME_URL}/intel-gmmlib_19.3.2_amd64.deb && \
 
     # DLIS-4658: Once Jetson build supports CUDA 11.8+, include compute_90 for Jetson.
     cuda_archs = "52;60;61;70;75;80;86"
-    if platform.machine != 'aarch64':
+    if platform.machine() != 'aarch64':
         cuda_archs += ";90"
 
     df += '''

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -218,10 +218,7 @@ RUN wget ${INTEL_COMPUTE_RUNTIME_URL}/intel-gmmlib_19.3.2_amd64.deb && \
     if FLAGS.ort_openvino is not None:
         ep_flags += ' --use_openvino CPU_FP32'
 
-    # DLIS-4658: Once Jetson build supports CUDA 11.8+, include compute_90 for Jetson.
-    cuda_archs = "52;60;61;70;75;80;86"
-    if platform.machine() != 'aarch64':
-        cuda_archs += ";90"
+    cuda_archs = "52;60;61;70;75;80;86;90"
 
     df += '''
 WORKDIR /workspace/onnxruntime

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -49,7 +49,6 @@ def target_platform():
         return FLAGS.target_platform
     return platform.system().lower()
 
-
 def dockerfile_common():
     df = '''
 ARG BASE_IMAGE={}
@@ -220,7 +219,7 @@ RUN wget ${INTEL_COMPUTE_RUNTIME_URL}/intel-gmmlib_19.3.2_amd64.deb && \
 
     # DLIS-4658: Once Jetson build supports CUDA 11.8+, include compute_90 for Jetson.
     cuda_archs = "52;60;61;70;75;80;86"
-    if target_platform() != 'jetpack':
+    if platform.machine != 'aarch64':
         cuda_archs += ";90"
 
     df += '''


### PR DESCRIPTION
Since Jetson's CUDA version now supports compute_90, build for that architecture as well.

- Remove special handling code to exclude compute_90 architecture for Jetson.