### PR TITLE
Add option to set ORT_DISABLE_ALL as optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Details regarding when to use these options and what to expect from them can be 
 * `inter_op_thread_count`: Sets the number of threads used to parallelize the execution of the graph (across nodes). If sequential execution is enabled this value is ignored. 
 A value of 0 means ORT will pick a default which is number of cores.
 * `execution_mode`: Controls whether operators in the graph are executed sequentially or in parallel. Usually when the model has many branches, setting this option to 1 .i.e. "parallel" will give you better performance. Default is 0 which is "sequential execution."
-* `level`: Refers to the graph optimization level. By default all optimizations are enabled. Allowed values are -1 and 1. -1 refers to BASIC optimizations and 1 refers to basic plus extended optimizations like fusions. Please find the details [here](https://onnxruntime.ai/docs/performance/graph-optimizations.html)
+* `level`: Refers to the graph optimization level. By default all optimizations are enabled. Allowed values are -1, 1 and 2. -1 refers to BASIC optimizations, 1 refers to basic plus extended optimizations like fusions and 2 refers to all optimizations being disabled. Please find the details [here](https://onnxruntime.ai/docs/performance/graph-optimizations.html).
 
 ```
 optimization {

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -227,6 +227,8 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
           optimization_level = GraphOptimizationLevel::ORT_ENABLE_BASIC;
         } else if (graph_level == 1) {
           optimization_level = GraphOptimizationLevel::ORT_ENABLE_EXTENDED;
+        } else if (graph_level == 2) {
+          optimization_level = GraphOptimizationLevel::ORT_DISABLE_ALL;
         }
       }
     }


### PR DESCRIPTION
Please let me know if it would be better to use a different value instead of 2.

This change allows users to set optimization->graph->level to DISABLE_ALL by setting 2. The reason for this is that sometimes specially when using a triton server for serving multiple models, we prefer users to optimize the model offline instead of online. This allows us to disable optimization greatly speeding up load time into triton onnxruntime backend.

This is my first contribution here, so please do let me know if I should change anything or add more tests. Given the code is 2 lines, I didn't initially add it.