### PR TITLE
Enable parallel instance loading backend attribute

### DIFF
--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -2784,5 +2784,21 @@ TRITONBACKEND_ModelInstanceExecute(
   return nullptr;  // success
 }
 
+TRITONSERVER_Error*
+TRITONBACKEND_GetBackendAttribute(
+    TRITONBACKEND_Backend* backend,
+    TRITONBACKEND_BackendAttribute* backend_attributes)
+{
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_VERBOSE,
+      "TRITONBACKEND_GetBackendAttribute: setting attributes");
+  // This backend can safely handle parallel calls to
+  // TRITONBACKEND_ModelInstanceInitialize (thread-safe).
+  RETURN_IF_ERROR(TRITONBACKEND_BackendAttributeSetParallelModelInstanceLoading(
+      backend_attributes, true));
+
+  return nullptr;
+}
+
 }  // extern "C"
 }}}  // namespace triton::backend::onnxruntime

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -2674,6 +2674,10 @@ TRITONBACKEND_ModelFinalize(TRITONBACKEND_Model* model)
 TRITONBACKEND_ISPEC TRITONSERVER_Error*
 TRITONBACKEND_ModelInstanceInitialize(TRITONBACKEND_ModelInstance* instance)
 {
+  // NOTE: If the corresponding TRITONBACKEND_BackendAttribute is enabled by the
+  // backend for parallel model instance loading, the
+  // TRITONBACKEND_ModelInstanceInitialize may be called concurrently.
+  // Therefore, this function should be thread-safe.
   const char* cname;
   RETURN_IF_ERROR(TRITONBACKEND_ModelInstanceName(instance, &cname));
   std::string name(cname);


### PR DESCRIPTION
Main area of concern appears to be this [model_state->LoadModel](https://github.com/triton-inference-server/onnxruntime_backend/blob/main/src/onnxruntime.cc#L366-L665) call made by [each instance](https://github.com/triton-inference-server/onnxruntime_backend/blob/d98c883455fd9ad1ccf179590afe7c186d0f6c41/src/onnxruntime.cc#L1034-L1036).

However, this function appears well protected, with most actions being done on a [cloned session for each instance](https://github.com/triton-inference-server/onnxruntime_backend/blob/d98c883455fd9ad1ccf179590afe7c186d0f6c41/src/onnxruntime.cc#L403-L408), and a called out [area of concern for OpenVINO](https://github.com/triton-inference-server/onnxruntime_backend/blob/d98c883455fd9ad1ccf179590afe7c186d0f6c41/src/onnxruntime.cc#L649-L655) which is already locked. 

---
Corresponding tests: https://github.com/triton-inference-server/server/pull/6126
Backend docs: https://github.com/triton-inference-server/backend/pull/87