### PR TITLE
Bumping min required cxx standard to 17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,9 @@ set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 
+# Use C++17 standard as Triton's minimum required.
+set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard which features are requested to build this target.")
+
 if (WIN32)
   if(TRITON_ENABLE_ONNXRUNTIME_OPENVINO)
     message(FATAL_ERROR
@@ -226,7 +229,7 @@ target_include_directories(
     ${TRITON_ONNXRUNTIME_INCLUDE_PATHS}
 )
 
-target_compile_features(triton-onnxruntime-backend PRIVATE cxx_std_11)
+target_compile_features(triton-onnxruntime-backend PRIVATE cxx_std_${TRITON_MIN_CXX_STANDARD})
 target_compile_options(
   triton-onnxruntime-backend PRIVATE
   $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:


### PR DESCRIPTION
This PR is one of the series PRs to update Triton to C++17 standard.

Introduced logic: either set `TRITON_MIN_CXX_STANDARD` to 17 or use cached value. Later,`TRITON_MIN_CXX_STANDARD`  is used to set min required standard through `target_compile_features`.