### PR TITLE
[TensorRT EP] Enable more trt options

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ To explore the usage of more parameters, follow the mapping table below and chec
 | trt_sparsity_enable                   | e.g: "1" or "true", "0" or "false"                           | trt_sparsity_enable                              | bool   |
 | trt_builder_optimization_level        | e.g: "3"                                                     | trt_builder_optimization_level                   | int    |
 | trt_auxiliary_streams                 | e.g: "-1"                                                    | trt_auxiliary_streams                            | int    |
-| trt_tactic_sources                    | e.g: "-CUDNN,+CUBLAS"; <br />Available keys: “CUBLAS”, “CUBLAS_LT”, “CUDNN” or “EDGE_MASK_CONVOLUTIONS”. | trt_tactic_sources                               | string |
+| trt_tactic_sources                    | e.g: "-CUDNN,+CUBLAS"; <br />Available keys: "CUBLAS", "CUBLAS_LT", "CUDNN" or "EDGE_MASK_CONVOLUTIONS". | trt_tactic_sources                               | string |
 | trt_extra_plugin_lib_paths            |                                                              | trt_extra_plugin_lib_paths                       | string |
 | trt_profile_min_shapes                | e.g: "input1:dim1xdimd2...,input2:dim1xdim2...,..."          | trt_profile_min_shapes                           | string |
 | trt_profile_max_shapes                | e.g: "input1:dim1xdimd2...,input2:dim1xdim2...,..."          | trt_profile_max_shapes                           | string |

--- a/README.md
+++ b/README.md
@@ -105,21 +105,21 @@ To explore the usage of more parameters, follow the mapping table below and chec
 | precision_mode                        | "FP16"                                  | trt_fp16_enable                                  | bool   |
 | precision_mode                        | "INT8"                                  | trt_int8_enable                                  | bool   |
 | int8_calibration_table_name           |                                         | trt_int8_calibration_table_name                  | string |
-| int8_calibration_table_name           |                                         | trt_int8_use_native_calibration_table            | bool   |
+| int8_use_native_calibration_table     | e.g: "1" for True, "0" for False        | trt_int8_use_native_calibration_table            | bool   |
 | trt_dla_enable                        |                                         | trt_dla_enable                                   | bool   |
 | trt_dla_core                          | e.g: "0"                                | trt_dla_core                                     | int    |
-| trt_engine_cache_enable               |                                         | trt_engine_cache_enable                          | bool   |
+| trt_engine_cache_enable               | e.g: "1" for True, "0" for False        | trt_engine_cache_enable                          | bool   |
 | trt_engine_cache_path                 |                                         | trt_engine_cache_path                            | string |
 | trt_engine_cache_prefix               |                                         | trt_engine_cache_prefix                          | string |
-| trt_dump_subgraphs                    |                                         | trt_dump_subgraphs                               | bool   |
-| trt_force_sequential_engine_build     |                                         | trt_force_sequential_engine_build                | bool   |
-| trt_context_memory_sharing_enable     |                                         | trt_context_memory_sharing_enable                | bool   |
-| trt_layer_norm_fp32_fallback          |                                         | trt_layer_norm_fp32_fallback                     | bool   |
-| trt_timing_cache_enable               |                                         | trt_timing_cache_enable                          | bool   |
-| trt_force_timing_cache                |                                         | trt_force_timing_cache                           | bool   |
-| trt_detailed_build_log                |                                         | trt_detailed_build_log                           | bool   |
-| trt_build_heuristics_enable           |                                         | trt_build_heuristics_enable                      | bool   |
-| trt_sparsity_enable                   |                                         | trt_sparsity_enable                              | bool   |
+| trt_dump_subgraphs                    | e.g: "1" for True, "0" for False        | trt_dump_subgraphs                               | bool   |
+| trt_force_sequential_engine_build     | e.g: "1" for True, "0" for False        | trt_force_sequential_engine_build                | bool   |
+| trt_context_memory_sharing_enable     | e.g: "1" for True, "0" for False        | trt_context_memory_sharing_enable                | bool   |
+| trt_layer_norm_fp32_fallback          | e.g: "1" for True, "0" for False        | trt_layer_norm_fp32_fallback                     | bool   |
+| trt_timing_cache_enable               | e.g: "1" for True, "0" for False        | trt_timing_cache_enable                          | bool   |
+| trt_force_timing_cache                | e.g: "1" for True, "0" for False        | trt_force_timing_cache                           | bool   |
+| trt_detailed_build_log                | e.g: "1" for True, "0" for False        | trt_detailed_build_log                           | bool   |
+| trt_build_heuristics_enable           | e.g: "1" for True, "0" for False        | trt_build_heuristics_enable                      | bool   |
+| trt_sparsity_enable                   | e.g: "1" for True, "0" for False        | trt_sparsity_enable                              | bool   |
 | trt_builder_optimization_level        | e.g: "3"                                | trt_builder_optimization_level                   | int    |
 | trt_auxiliary_streams                 | e.g: "-1"                               | trt_auxiliary_streams                            | int    |
 | trt_tactic_sources                    | e.g. "-CUDNN,+CUBLAS"                   | trt_tactic_sources                               | string |
@@ -127,7 +127,7 @@ To explore the usage of more parameters, follow the mapping table below and chec
 | trt_profile_min_shapes                |                                         | trt_profile_min_shapes                           | string |
 | trt_profile_max_shapes                |                                         | trt_profile_max_shapes                           | string |
 | trt_profile_opt_shapes                |                                         | trt_profile_opt_shapes                           | string |
-| trt_cuda_graph_enable                 |                                         | trt_cuda_graph_enable                            | bool   |
+| trt_cuda_graph_enable                 | e.g: "1" for True, "0" for False        | trt_cuda_graph_enable                            | bool   |
 
 The section of model config file specifying these parameters will look like:
 
@@ -140,6 +140,7 @@ optimization { execution_accelerators {
     name : "tensorrt"
     parameters { key: "precision_mode" value: "FP16" }
     parameters { key: "max_workspace_size_bytes" value: "1073741824" }}
+    parameters { key: "trt_engine_cache_enable" value: "1" }}
   ]
 }}
 .

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ To explore the usage of more parameters, follow the mapping table below and chec
 | trt_context_memory_sharing_enable     | e.g: "1" for True, "0" for False        | trt_context_memory_sharing_enable                | bool   |
 | trt_layer_norm_fp32_fallback          | e.g: "1" for True, "0" for False        | trt_layer_norm_fp32_fallback                     | bool   |
 | trt_timing_cache_enable               | e.g: "1" for True, "0" for False        | trt_timing_cache_enable                          | bool   |
-| trt_timing_cache_path                 |                                         | trt_timing_cache_path                            | string |
 | trt_force_timing_cache                | e.g: "1" for True, "0" for False        | trt_force_timing_cache                           | bool   |
 | trt_detailed_build_log                | e.g: "1" for True, "0" for False        | trt_detailed_build_log                           | bool   |
 | trt_build_heuristics_enable           | e.g: "1" for True, "0" for False        | trt_build_heuristics_enable                      | bool   |

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ TensorRT can be used in conjunction with an ONNX model to further optimize the p
 
 To explore the usage of more parameters, follow the mapping table below and check [ONNX Runtime doc](https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#execution-provider-options) for detail.
 
+> Please link to the latest ONNX Runtime binaries in CMake or build from [main branch of ONNX Runtime](https://github.com/microsoft/onnxruntime/tree/main) to enable latest options.
+
 ### Parameter mapping between ONNX Runtime and Triton-ort
 
 | Parameter: key in Triton model config | Parameter: value in Triton model config                      | Corresponding TensorRT EP option in ONNX Runtime | Type   |
@@ -116,13 +118,14 @@ To explore the usage of more parameters, follow the mapping table below and chec
 | trt_context_memory_sharing_enable     | e.g: "1" or "true", "0" or "false"                           | trt_context_memory_sharing_enable                | bool   |
 | trt_layer_norm_fp32_fallback          | e.g: "1" or "true", "0" or "false"                           | trt_layer_norm_fp32_fallback                     | bool   |
 | trt_timing_cache_enable               | e.g: "1" or "true", "0" or "false"                           | trt_timing_cache_enable                          | bool   |
+| trt_timing_cache_path                 |                                                              | trt_timing_cache_path                            | string |
 | trt_force_timing_cache                | e.g: "1" or "true", "0" or "false"                           | trt_force_timing_cache                           | bool   |
 | trt_detailed_build_log                | e.g: "1" or "true", "0" or "false"                           | trt_detailed_build_log                           | bool   |
 | trt_build_heuristics_enable           | e.g: "1" or "true", "0" or "false"                           | trt_build_heuristics_enable                      | bool   |
 | trt_sparsity_enable                   | e.g: "1" or "true", "0" or "false"                           | trt_sparsity_enable                              | bool   |
 | trt_builder_optimization_level        | e.g: "3"                                                     | trt_builder_optimization_level                   | int    |
 | trt_auxiliary_streams                 | e.g: "-1"                                                    | trt_auxiliary_streams                            | int    |
-| trt_tactic_sources                    | e.g: "-CUDNN,+CUBLAS"; <br />Available keys: "CUBLAS", "CUBLAS_LT", "CUDNN" or "EDGE_MASK_CONVOLUTIONS". | trt_tactic_sources                               | string |
+| trt_tactic_sources                    | e.g: "-CUDNN,+CUBLAS";                                       | trt_tactic_sources                               | string |
 | trt_extra_plugin_lib_paths            |                                                              | trt_extra_plugin_lib_paths                       | string |
 | trt_profile_min_shapes                | e.g: "input1:dim1xdimd2...,input2:dim1xdim2...,..."          | trt_profile_min_shapes                           | string |
 | trt_profile_max_shapes                | e.g: "input1:dim1xdimd2...,input2:dim1xdim2...,..."          | trt_profile_max_shapes                           | string |

--- a/README.md
+++ b/README.md
@@ -97,37 +97,40 @@ To explore the usage of more parameters, follow the mapping table below and chec
 
 ### Parameter mapping between ONNX Runtime and Triton-ort
 
-| Parameter: key in Triton model config | Parameter: value in Triton model config | Corresponding TensorRT EP option in ONNX Runtime | Type   |
-| ------------------------------------- | --------------------------------------- | :----------------------------------------------- | :----- |
-| max_workspace_size_bytes              | e.g: "4294967296"                       | trt_max_workspace_size                           | int    |
-| trt_max_partition_iterations          | e.g: "1000"                             | trt_max_partition_iterations                     | int    |
-| trt_min_subgraph_size                 | e.g: "1"                                | trt_min_subgraph_size                            | int    |
-| precision_mode                        | "FP16"                                  | trt_fp16_enable                                  | bool   |
-| precision_mode                        | "INT8"                                  | trt_int8_enable                                  | bool   |
-| int8_calibration_table_name           |                                         | trt_int8_calibration_table_name                  | string |
-| int8_use_native_calibration_table     | e.g: "1" or "true", "0" or "false"      | trt_int8_use_native_calibration_table            | bool   |
-| trt_dla_enable                        |                                         | trt_dla_enable                                   | bool   |
-| trt_dla_core                          | e.g: "0"                                | trt_dla_core                                     | int    |
-| trt_engine_cache_enable               | e.g: "1" or "true", "0" or "false"      | trt_engine_cache_enable                          | bool   |
-| trt_engine_cache_path                 |                                         | trt_engine_cache_path                            | string |
-| trt_engine_cache_prefix               |                                         | trt_engine_cache_prefix                          | string |
-| trt_dump_subgraphs                    | e.g: "1" or "true", "0" or "false"      | trt_dump_subgraphs                               | bool   |
-| trt_force_sequential_engine_build     | e.g: "1" or "true", "0" or "false"      | trt_force_sequential_engine_build                | bool   |
-| trt_context_memory_sharing_enable     | e.g: "1" or "true", "0" or "false"      | trt_context_memory_sharing_enable                | bool   |
-| trt_layer_norm_fp32_fallback          | e.g: "1" or "true", "0" or "false"      | trt_layer_norm_fp32_fallback                     | bool   |
-| trt_timing_cache_enable               | e.g: "1" or "true", "0" or "false"      | trt_timing_cache_enable                          | bool   |
-| trt_force_timing_cache                | e.g: "1" or "true", "0" or "false"      | trt_force_timing_cache                           | bool   |
-| trt_detailed_build_log                | e.g: "1" or "true", "0" or "false"      | trt_detailed_build_log                           | bool   |
-| trt_build_heuristics_enable           | e.g: "1" or "true", "0" or "false"      | trt_build_heuristics_enable                      | bool   |
-| trt_sparsity_enable                   | e.g: "1" or "true", "0" or "false"      | trt_sparsity_enable                              | bool   |
-| trt_builder_optimization_level        | e.g: "3"                                | trt_builder_optimization_level                   | int    |
-| trt_auxiliary_streams                 | e.g: "-1"                               | trt_auxiliary_streams                            | int    |
-| trt_tactic_sources                    | e.g. "-CUDNN,+CUBLAS"                   | trt_tactic_sources                               | string |
-| trt_extra_plugin_lib_paths            |                                         | trt_extra_plugin_lib_paths                       | string |
-| trt_profile_min_shapes                |                                         | trt_profile_min_shapes                           | string |
-| trt_profile_max_shapes                |                                         | trt_profile_max_shapes                           | string |
-| trt_profile_opt_shapes                |                                         | trt_profile_opt_shapes                           | string |
-| trt_cuda_graph_enable                 | e.g: "1" or "true", "0" or "false"      | trt_cuda_graph_enable                            | bool   |
+| Parameter: key in Triton model config | Parameter: value in Triton model config                      | Corresponding TensorRT EP option in ONNX Runtime | Type   |
+| ------------------------------------- | ------------------------------------------------------------ | :----------------------------------------------- | :----- |
+| max_workspace_size_bytes              | e.g: "4294967296"                                            | trt_max_workspace_size                           | int    |
+| trt_max_partition_iterations          | e.g: "1000"                                                  | trt_max_partition_iterations                     | int    |
+| trt_min_subgraph_size                 | e.g: "1"                                                     | trt_min_subgraph_size                            | int    |
+| precision_mode                        | "FP16"                                                       | trt_fp16_enable                                  | bool   |
+| precision_mode                        | "INT8"                                                       | trt_int8_enable                                  | bool   |
+| int8_calibration_table_name           |                                                              | trt_int8_calibration_table_name                  | string |
+| int8_use_native_calibration_table     | e.g: "1" or "true", "0" or "false"                           | trt_int8_use_native_calibration_table            | bool   |
+| trt_dla_enable                        |                                                              | trt_dla_enable                                   | bool   |
+| trt_dla_core                          | e.g: "0"                                                     | trt_dla_core                                     | int    |
+| trt_engine_cache_enable               | e.g: "1" or "true", "0" or "false"                           | trt_engine_cache_enable                          | bool   |
+| trt_engine_cache_path                 |                                                              | trt_engine_cache_path                            | string |
+| trt_engine_cache_prefix               |                                                              | trt_engine_cache_prefix                          | string |
+| trt_dump_subgraphs                    | e.g: "1" or "true", "0" or "false"                           | trt_dump_subgraphs                               | bool   |
+| trt_force_sequential_engine_build     | e.g: "1" or "true", "0" or "false"                           | trt_force_sequential_engine_build                | bool   |
+| trt_context_memory_sharing_enable     | e.g: "1" or "true", "0" or "false"                           | trt_context_memory_sharing_enable                | bool   |
+| trt_layer_norm_fp32_fallback          | e.g: "1" or "true", "0" or "false"                           | trt_layer_norm_fp32_fallback                     | bool   |
+| trt_timing_cache_enable               | e.g: "1" or "true", "0" or "false"                           | trt_timing_cache_enable                          | bool   |
+| trt_force_timing_cache                | e.g: "1" or "true", "0" or "false"                           | trt_force_timing_cache                           | bool   |
+| trt_detailed_build_log                | e.g: "1" or "true", "0" or "false"                           | trt_detailed_build_log                           | bool   |
+| trt_build_heuristics_enable           | e.g: "1" or "true", "0" or "false"                           | trt_build_heuristics_enable                      | bool   |
+| trt_sparsity_enable                   | e.g: "1" or "true", "0" or "false"                           | trt_sparsity_enable                              | bool   |
+| trt_builder_optimization_level        | e.g: "3"                                                     | trt_builder_optimization_level                   | int    |
+| trt_auxiliary_streams                 | e.g: "-1"                                                    | trt_auxiliary_streams                            | int    |
+| trt_tactic_sources                    | e.g: "-CUDNN,+CUBLAS"; <br />Available keys: “CUBLAS”, “CUBLAS_LT”, “CUDNN” or “EDGE_MASK_CONVOLUTIONS”. | trt_tactic_sources                               | string |
+| trt_extra_plugin_lib_paths            |                                                              | trt_extra_plugin_lib_paths                       | string |
+| trt_profile_min_shapes                | e.g: "input1:dim1xdimd2...,input2:dim1xdim2...,..."          | trt_profile_min_shapes                           | string |
+| trt_profile_max_shapes                | e.g: "input1:dim1xdimd2...,input2:dim1xdim2...,..."          | trt_profile_max_shapes                           | string |
+| trt_profile_opt_shapes                | e.g: "input1:dim1xdimd2...,input2:dim1xdim2...,..."          | trt_profile_opt_shapes                           | string |
+| trt_cuda_graph_enable                 | e.g: "1" or "true", "0" or "false"                           | trt_cuda_graph_enable                            | bool   |
+| trt_dump_ep_context_model             | e.g: "1" or "true", "0" or "false"                           | trt_dump_ep_context_model                        | bool   |
+| trt_ep_context_file_path              |                                                              | trt_ep_context_file_path                         | string |
+| trt_ep_context_embed_mode             | e.g: "1"                                                     | trt_ep_context_embed_mode                        | int    |
 
 The section of model config file specifying these parameters will look like:
 

--- a/README.md
+++ b/README.md
@@ -105,21 +105,21 @@ To explore the usage of more parameters, follow the mapping table below and chec
 | precision_mode                        | "FP16"                                  | trt_fp16_enable                                  | bool   |
 | precision_mode                        | "INT8"                                  | trt_int8_enable                                  | bool   |
 | int8_calibration_table_name           |                                         | trt_int8_calibration_table_name                  | string |
-| int8_use_native_calibration_table     | e.g: true or false                      | trt_int8_use_native_calibration_table            | bool   |
+| int8_use_native_calibration_table     | e.g: "1" or "true", "0" or "false"      | trt_int8_use_native_calibration_table            | bool   |
 | trt_dla_enable                        |                                         | trt_dla_enable                                   | bool   |
 | trt_dla_core                          | e.g: "0"                                | trt_dla_core                                     | int    |
-| trt_engine_cache_enable               | e.g: true or false                      | trt_engine_cache_enable                          | bool   |
+| trt_engine_cache_enable               | e.g: "1" or "true", "0" or "false"      | trt_engine_cache_enable                          | bool   |
 | trt_engine_cache_path                 |                                         | trt_engine_cache_path                            | string |
 | trt_engine_cache_prefix               |                                         | trt_engine_cache_prefix                          | string |
-| trt_dump_subgraphs                    | e.g: true or false                      | trt_dump_subgraphs                               | bool   |
-| trt_force_sequential_engine_build     | e.g: true or false                      | trt_force_sequential_engine_build                | bool   |
-| trt_context_memory_sharing_enable     | e.g: true or false                      | trt_context_memory_sharing_enable                | bool   |
-| trt_layer_norm_fp32_fallback          | e.g: true or false                      | trt_layer_norm_fp32_fallback                     | bool   |
-| trt_timing_cache_enable               | e.g: true or false                      | trt_timing_cache_enable                          | bool   |
-| trt_force_timing_cache                | e.g: true or false                      | trt_force_timing_cache                           | bool   |
-| trt_detailed_build_log                | e.g: true or false                      | trt_detailed_build_log                           | bool   |
-| trt_build_heuristics_enable           | e.g: true or false                      | trt_build_heuristics_enable                      | bool   |
-| trt_sparsity_enable                   | e.g: true or false                      | trt_sparsity_enable                              | bool   |
+| trt_dump_subgraphs                    | e.g: "1" or "true", "0" or "false"      | trt_dump_subgraphs                               | bool   |
+| trt_force_sequential_engine_build     | e.g: "1" or "true", "0" or "false"      | trt_force_sequential_engine_build                | bool   |
+| trt_context_memory_sharing_enable     | e.g: "1" or "true", "0" or "false"      | trt_context_memory_sharing_enable                | bool   |
+| trt_layer_norm_fp32_fallback          | e.g: "1" or "true", "0" or "false"      | trt_layer_norm_fp32_fallback                     | bool   |
+| trt_timing_cache_enable               | e.g: "1" or "true", "0" or "false"      | trt_timing_cache_enable                          | bool   |
+| trt_force_timing_cache                | e.g: "1" or "true", "0" or "false"      | trt_force_timing_cache                           | bool   |
+| trt_detailed_build_log                | e.g: "1" or "true", "0" or "false"      | trt_detailed_build_log                           | bool   |
+| trt_build_heuristics_enable           | e.g: "1" or "true", "0" or "false"      | trt_build_heuristics_enable                      | bool   |
+| trt_sparsity_enable                   | e.g: "1" or "true", "0" or "false"      | trt_sparsity_enable                              | bool   |
 | trt_builder_optimization_level        | e.g: "3"                                | trt_builder_optimization_level                   | int    |
 | trt_auxiliary_streams                 | e.g: "-1"                               | trt_auxiliary_streams                            | int    |
 | trt_tactic_sources                    | e.g. "-CUDNN,+CUBLAS"                   | trt_tactic_sources                               | string |
@@ -127,7 +127,7 @@ To explore the usage of more parameters, follow the mapping table below and chec
 | trt_profile_min_shapes                |                                         | trt_profile_min_shapes                           | string |
 | trt_profile_max_shapes                |                                         | trt_profile_max_shapes                           | string |
 | trt_profile_opt_shapes                |                                         | trt_profile_opt_shapes                           | string |
-| trt_cuda_graph_enable                 | e.g: true or false                      | trt_cuda_graph_enable                            | bool   |
+| trt_cuda_graph_enable                 | e.g: "1" or "true", "0" or "false"      | trt_cuda_graph_enable                            | bool   |
 
 The section of model config file specifying these parameters will look like:
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ To explore the usage of more parameters, follow the mapping table below and chec
 | trt_context_memory_sharing_enable     | e.g: "1" for True, "0" for False        | trt_context_memory_sharing_enable                | bool   |
 | trt_layer_norm_fp32_fallback          | e.g: "1" for True, "0" for False        | trt_layer_norm_fp32_fallback                     | bool   |
 | trt_timing_cache_enable               | e.g: "1" for True, "0" for False        | trt_timing_cache_enable                          | bool   |
+| trt_timing_cache_path                 |                                         | trt_timing_cache_path                            | string |
 | trt_force_timing_cache                | e.g: "1" for True, "0" for False        | trt_force_timing_cache                           | bool   |
 | trt_detailed_build_log                | e.g: "1" for True, "0" for False        | trt_detailed_build_log                           | bool   |
 | trt_build_heuristics_enable           | e.g: "1" for True, "0" for False        | trt_build_heuristics_enable                      | bool   |

--- a/README.md
+++ b/README.md
@@ -105,21 +105,21 @@ To explore the usage of more parameters, follow the mapping table below and chec
 | precision_mode                        | "FP16"                                  | trt_fp16_enable                                  | bool   |
 | precision_mode                        | "INT8"                                  | trt_int8_enable                                  | bool   |
 | int8_calibration_table_name           |                                         | trt_int8_calibration_table_name                  | string |
-| int8_use_native_calibration_table     | e.g: "1" for True, "0" for False        | trt_int8_use_native_calibration_table            | bool   |
+| int8_use_native_calibration_table     | e.g: true or false                      | trt_int8_use_native_calibration_table            | bool   |
 | trt_dla_enable                        |                                         | trt_dla_enable                                   | bool   |
 | trt_dla_core                          | e.g: "0"                                | trt_dla_core                                     | int    |
-| trt_engine_cache_enable               | e.g: "1" for True, "0" for False        | trt_engine_cache_enable                          | bool   |
+| trt_engine_cache_enable               | e.g: true or false                      | trt_engine_cache_enable                          | bool   |
 | trt_engine_cache_path                 |                                         | trt_engine_cache_path                            | string |
 | trt_engine_cache_prefix               |                                         | trt_engine_cache_prefix                          | string |
-| trt_dump_subgraphs                    | e.g: "1" for True, "0" for False        | trt_dump_subgraphs                               | bool   |
-| trt_force_sequential_engine_build     | e.g: "1" for True, "0" for False        | trt_force_sequential_engine_build                | bool   |
-| trt_context_memory_sharing_enable     | e.g: "1" for True, "0" for False        | trt_context_memory_sharing_enable                | bool   |
-| trt_layer_norm_fp32_fallback          | e.g: "1" for True, "0" for False        | trt_layer_norm_fp32_fallback                     | bool   |
-| trt_timing_cache_enable               | e.g: "1" for True, "0" for False        | trt_timing_cache_enable                          | bool   |
-| trt_force_timing_cache                | e.g: "1" for True, "0" for False        | trt_force_timing_cache                           | bool   |
-| trt_detailed_build_log                | e.g: "1" for True, "0" for False        | trt_detailed_build_log                           | bool   |
-| trt_build_heuristics_enable           | e.g: "1" for True, "0" for False        | trt_build_heuristics_enable                      | bool   |
-| trt_sparsity_enable                   | e.g: "1" for True, "0" for False        | trt_sparsity_enable                              | bool   |
+| trt_dump_subgraphs                    | e.g: true or false                      | trt_dump_subgraphs                               | bool   |
+| trt_force_sequential_engine_build     | e.g: true or false                      | trt_force_sequential_engine_build                | bool   |
+| trt_context_memory_sharing_enable     | e.g: true or false                      | trt_context_memory_sharing_enable                | bool   |
+| trt_layer_norm_fp32_fallback          | e.g: true or false                      | trt_layer_norm_fp32_fallback                     | bool   |
+| trt_timing_cache_enable               | e.g: true or false                      | trt_timing_cache_enable                          | bool   |
+| trt_force_timing_cache                | e.g: true or false                      | trt_force_timing_cache                           | bool   |
+| trt_detailed_build_log                | e.g: true or false                      | trt_detailed_build_log                           | bool   |
+| trt_build_heuristics_enable           | e.g: true or false                      | trt_build_heuristics_enable                      | bool   |
+| trt_sparsity_enable                   | e.g: true or false                      | trt_sparsity_enable                              | bool   |
 | trt_builder_optimization_level        | e.g: "3"                                | trt_builder_optimization_level                   | int    |
 | trt_auxiliary_streams                 | e.g: "-1"                               | trt_auxiliary_streams                            | int    |
 | trt_tactic_sources                    | e.g. "-CUDNN,+CUBLAS"                   | trt_tactic_sources                               | string |
@@ -127,7 +127,7 @@ To explore the usage of more parameters, follow the mapping table below and chec
 | trt_profile_min_shapes                |                                         | trt_profile_min_shapes                           | string |
 | trt_profile_max_shapes                |                                         | trt_profile_max_shapes                           | string |
 | trt_profile_opt_shapes                |                                         | trt_profile_opt_shapes                           | string |
-| trt_cuda_graph_enable                 | e.g: "1" for True, "0" for False        | trt_cuda_graph_enable                            | bool   |
+| trt_cuda_graph_enable                 | e.g: true or false                      | trt_cuda_graph_enable                            | bool   |
 
 The section of model config file specifying these parameters will look like:
 

--- a/README.md
+++ b/README.md
@@ -97,43 +97,43 @@ To explore the usage of more parameters, follow the mapping table below and chec
 
 > Please link to the latest ONNX Runtime binaries in CMake or build from [main branch of ONNX Runtime](https://github.com/microsoft/onnxruntime/tree/main) to enable latest options.
 
-### Parameter mapping between ONNX Runtime and Triton-ort
+### Parameter mapping between ONNX Runtime and Triton ONNXRuntime Backend
 
-| Parameter: key in Triton model config | Parameter: value in Triton model config                      | Corresponding TensorRT EP option in ONNX Runtime | Type   |
-| ------------------------------------- | ------------------------------------------------------------ | :----------------------------------------------- | :----- |
-| max_workspace_size_bytes              | e.g: "4294967296"                                            | trt_max_workspace_size                           | int    |
-| trt_max_partition_iterations          | e.g: "1000"                                                  | trt_max_partition_iterations                     | int    |
-| trt_min_subgraph_size                 | e.g: "1"                                                     | trt_min_subgraph_size                            | int    |
-| precision_mode                        | "FP16"                                                       | trt_fp16_enable                                  | bool   |
-| precision_mode                        | "INT8"                                                       | trt_int8_enable                                  | bool   |
-| int8_calibration_table_name           |                                                              | trt_int8_calibration_table_name                  | string |
-| int8_use_native_calibration_table     | e.g: "1" or "true", "0" or "false"                           | trt_int8_use_native_calibration_table            | bool   |
-| trt_dla_enable                        |                                                              | trt_dla_enable                                   | bool   |
-| trt_dla_core                          | e.g: "0"                                                     | trt_dla_core                                     | int    |
-| trt_engine_cache_enable               | e.g: "1" or "true", "0" or "false"                           | trt_engine_cache_enable                          | bool   |
-| trt_engine_cache_path                 |                                                              | trt_engine_cache_path                            | string |
-| trt_engine_cache_prefix               |                                                              | trt_engine_cache_prefix                          | string |
-| trt_dump_subgraphs                    | e.g: "1" or "true", "0" or "false"                           | trt_dump_subgraphs                               | bool   |
-| trt_force_sequential_engine_build     | e.g: "1" or "true", "0" or "false"                           | trt_force_sequential_engine_build                | bool   |
-| trt_context_memory_sharing_enable     | e.g: "1" or "true", "0" or "false"                           | trt_context_memory_sharing_enable                | bool   |
-| trt_layer_norm_fp32_fallback          | e.g: "1" or "true", "0" or "false"                           | trt_layer_norm_fp32_fallback                     | bool   |
-| trt_timing_cache_enable               | e.g: "1" or "true", "0" or "false"                           | trt_timing_cache_enable                          | bool   |
-| trt_timing_cache_path                 |                                                              | trt_timing_cache_path                            | string |
-| trt_force_timing_cache                | e.g: "1" or "true", "0" or "false"                           | trt_force_timing_cache                           | bool   |
-| trt_detailed_build_log                | e.g: "1" or "true", "0" or "false"                           | trt_detailed_build_log                           | bool   |
-| trt_build_heuristics_enable           | e.g: "1" or "true", "0" or "false"                           | trt_build_heuristics_enable                      | bool   |
-| trt_sparsity_enable                   | e.g: "1" or "true", "0" or "false"                           | trt_sparsity_enable                              | bool   |
-| trt_builder_optimization_level        | e.g: "3"                                                     | trt_builder_optimization_level                   | int    |
-| trt_auxiliary_streams                 | e.g: "-1"                                                    | trt_auxiliary_streams                            | int    |
-| trt_tactic_sources                    | e.g: "-CUDNN,+CUBLAS";                                       | trt_tactic_sources                               | string |
-| trt_extra_plugin_lib_paths            |                                                              | trt_extra_plugin_lib_paths                       | string |
-| trt_profile_min_shapes                | e.g: "input1:dim1xdimd2...,input2:dim1xdim2...,..."          | trt_profile_min_shapes                           | string |
-| trt_profile_max_shapes                | e.g: "input1:dim1xdimd2...,input2:dim1xdim2...,..."          | trt_profile_max_shapes                           | string |
-| trt_profile_opt_shapes                | e.g: "input1:dim1xdimd2...,input2:dim1xdim2...,..."          | trt_profile_opt_shapes                           | string |
-| trt_cuda_graph_enable                 | e.g: "1" or "true", "0" or "false"                           | trt_cuda_graph_enable                            | bool   |
-| trt_dump_ep_context_model             | e.g: "1" or "true", "0" or "false"                           | trt_dump_ep_context_model                        | bool   |
-| trt_ep_context_file_path              |                                                              | trt_ep_context_file_path                         | string |
-| trt_ep_context_embed_mode             | e.g: "1"                                                     | trt_ep_context_embed_mode                        | int    |
+| Key in Triton model configuration | Value in Triton model config                        | Corresponding TensorRT EP option in ONNX Runtime | Type   |
+| --------------------------------- | --------------------------------------------------- | :----------------------------------------------- | :----- |
+| max_workspace_size_bytes          | e.g: "4294967296"                                   | trt_max_workspace_size                           | int    |
+| trt_max_partition_iterations      | e.g: "1000"                                         | trt_max_partition_iterations                     | int    |
+| trt_min_subgraph_size             | e.g: "1"                                            | trt_min_subgraph_size                            | int    |
+| precision_mode                    | "FP16"                                              | trt_fp16_enable                                  | bool   |
+| precision_mode                    | "INT8"                                              | trt_int8_enable                                  | bool   |
+| int8_calibration_table_name       |                                                     | trt_int8_calibration_table_name                  | string |
+| int8_use_native_calibration_table | e.g: "1" or "true", "0" or "false"                  | trt_int8_use_native_calibration_table            | bool   |
+| trt_dla_enable                    |                                                     | trt_dla_enable                                   | bool   |
+| trt_dla_core                      | e.g: "0"                                            | trt_dla_core                                     | int    |
+| trt_engine_cache_enable           | e.g: "1" or "true", "0" or "false"                  | trt_engine_cache_enable                          | bool   |
+| trt_engine_cache_path             |                                                     | trt_engine_cache_path                            | string |
+| trt_engine_cache_prefix           |                                                     | trt_engine_cache_prefix                          | string |
+| trt_dump_subgraphs                | e.g: "1" or "true", "0" or "false"                  | trt_dump_subgraphs                               | bool   |
+| trt_force_sequential_engine_build | e.g: "1" or "true", "0" or "false"                  | trt_force_sequential_engine_build                | bool   |
+| trt_context_memory_sharing_enable | e.g: "1" or "true", "0" or "false"                  | trt_context_memory_sharing_enable                | bool   |
+| trt_layer_norm_fp32_fallback      | e.g: "1" or "true", "0" or "false"                  | trt_layer_norm_fp32_fallback                     | bool   |
+| trt_timing_cache_enable           | e.g: "1" or "true", "0" or "false"                  | trt_timing_cache_enable                          | bool   |
+| trt_timing_cache_path             |                                                     | trt_timing_cache_path                            | string |
+| trt_force_timing_cache            | e.g: "1" or "true", "0" or "false"                  | trt_force_timing_cache                           | bool   |
+| trt_detailed_build_log            | e.g: "1" or "true", "0" or "false"                  | trt_detailed_build_log                           | bool   |
+| trt_build_heuristics_enable       | e.g: "1" or "true", "0" or "false"                  | trt_build_heuristics_enable                      | bool   |
+| trt_sparsity_enable               | e.g: "1" or "true", "0" or "false"                  | trt_sparsity_enable                              | bool   |
+| trt_builder_optimization_level    | e.g: "3"                                            | trt_builder_optimization_level                   | int    |
+| trt_auxiliary_streams             | e.g: "-1"                                           | trt_auxiliary_streams                            | int    |
+| trt_tactic_sources                | e.g: "-CUDNN,+CUBLAS";                              | trt_tactic_sources                               | string |
+| trt_extra_plugin_lib_paths        |                                                     | trt_extra_plugin_lib_paths                       | string |
+| trt_profile_min_shapes            | e.g: "input1:dim1xdimd2...,input2:dim1xdim2...,..." | trt_profile_min_shapes                           | string |
+| trt_profile_max_shapes            | e.g: "input1:dim1xdimd2...,input2:dim1xdim2...,..." | trt_profile_max_shapes                           | string |
+| trt_profile_opt_shapes            | e.g: "input1:dim1xdimd2...,input2:dim1xdim2...,..." | trt_profile_opt_shapes                           | string |
+| trt_cuda_graph_enable             | e.g: "1" or "true", "0" or "false"                  | trt_cuda_graph_enable                            | bool   |
+| trt_dump_ep_context_model         | e.g: "1" or "true", "0" or "false"                  | trt_dump_ep_context_model                        | bool   |
+| trt_ep_context_file_path          |                                                     | trt_ep_context_file_path                         | string |
+| trt_ep_context_embed_mode         | e.g: "1"                                            | trt_ep_context_embed_mode                        | int    |
 
 The section of model config file specifying these parameters will look like:
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ TensorRT can be used in conjunction with an ONNX model to further optimize the p
 * `trt_engine_cache_enable`: Enable engine caching.
 * `trt_engine_cache_path`: Specify engine cache path.
 
-For more option usage, follow the mapping table below and check [here](https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#execution-provider-options) for more detail.
+To explore the usage of more parameters, follow the mapping table below and check [ONNX Runtime doc](https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#execution-provider-options) for detail.
 
 ### Parameter mapping between ONNX Runtime and Triton-ort
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,41 @@ TensorRT can be used in conjunction with an ONNX model to further optimize the p
 * `trt_engine_cache_enable`: Enable engine caching.
 * `trt_engine_cache_path`: Specify engine cache path.
 
+For more option usage, follow the mapping table below and check [here](https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#execution-provider-options) for more detail.
+
+### Parameter mapping between ONNX Runtime and Triton-ort
+
+| TensorRT Session Options in ONNX Runtime | Type   | Parameter: key in Triton model config | Parameter: value in Triton model config |
+| :--------------------------------------- | :----- | ------------------------------------- | --------------------------------------- |
+| trt_max_workspace_size                   | int    | max_workspace_size_bytes              | e.g: 4294967296                         |
+| trt_max_partition_iterations             | int    | trt_max_partition_iterations          | e.g: 1000                               |
+| trt_min_subgraph_size                    | int    | trt_min_subgraph_size                 | e.g: 1                                  |
+| trt_fp16_enable                          | bool   | precision_mode                        | FP16                                    |
+| trt_int8_enable                          | bool   | precision_mode                        | INT8                                    |
+| trt_int8_calibration_table_name          | string | int8_calibration_table_name           |                                         |
+| trt_int8_use_native_calibration_table    | bool   | int8_calibration_table_name           |                                         |
+| trt_dla_enable                           | bool   | trt_dla_enable                        |                                         |
+| trt_dla_core                             | int    | trt_dla_core                          | e.g: 0                                  |
+| trt_engine_cache_enable                  | bool   | trt_engine_cache_enable               |                                         |
+| trt_engine_cache_path                    | string | trt_engine_cache_path                 |                                         |
+| trt_engine_cache_prefix                  | string | trt_engine_cache_prefix               |                                         |
+| trt_dump_subgraphs                       | bool   | trt_dump_subgraphs                    |                                         |
+| trt_force_sequential_engine_build        | bool   | trt_force_sequential_engine_build     |                                         |
+| trt_context_memory_sharing_enable        | bool   | trt_context_memory_sharing_enable     |                                         |
+| trt_layer_norm_fp32_fallback             | bool   | trt_layer_norm_fp32_fallback          |                                         |
+| trt_timing_cache_enable                  | bool   | trt_timing_cache_enable               |                                         |
+| trt_force_timing_cache                   | bool   | trt_force_timing_cache                |                                         |
+| trt_detailed_build_log                   | bool   | trt_detailed_build_log                |                                         |
+| trt_build_heuristics_enable              | bool   | trt_build_heuristics_enable           |                                         |
+| trt_sparsity_enable                      | bool   | trt_sparsity_enable                   |                                         |
+| trt_builder_optimization_level           | int    | trt_builder_optimization_level        | e.g: 3                                  |
+| trt_auxiliary_streams                    | int    | trt_auxiliary_streams                 | e.g: -1                                 |
+| trt_tactic_sources                       | string | trt_tactic_sources                    | e.g. “-CUDNN,+CUBLAS”                   |
+| trt_extra_plugin_lib_paths               | string | trt_extra_plugin_lib_paths            |                                         |
+| trt_profile_min_shapes                   | string | trt_profile_min_shapes                |                                         |
+| trt_profile_max_shapes                   | string | trt_profile_max_shapes                |                                         |
+| trt_profile_opt_shapes                   | string | trt_profile_opt_shapes                |                                         |
+| trt_cuda_graph_enable                    | bool   | trt_cuda_graph_enable                 |                                         |
 The section of model config file specifying these parameters will look like:
 
 ```

--- a/README.md
+++ b/README.md
@@ -97,37 +97,38 @@ For more option usage, follow the mapping table below and check [here](https://o
 
 ### Parameter mapping between ONNX Runtime and Triton-ort
 
-| TensorRT Session Options in ONNX Runtime | Type   | Parameter: key in Triton model config | Parameter: value in Triton model config |
-| :--------------------------------------- | :----- | ------------------------------------- | --------------------------------------- |
-| trt_max_workspace_size                   | int    | max_workspace_size_bytes              | e.g: 4294967296                         |
-| trt_max_partition_iterations             | int    | trt_max_partition_iterations          | e.g: 1000                               |
-| trt_min_subgraph_size                    | int    | trt_min_subgraph_size                 | e.g: 1                                  |
-| trt_fp16_enable                          | bool   | precision_mode                        | FP16                                    |
-| trt_int8_enable                          | bool   | precision_mode                        | INT8                                    |
-| trt_int8_calibration_table_name          | string | int8_calibration_table_name           |                                         |
-| trt_int8_use_native_calibration_table    | bool   | int8_calibration_table_name           |                                         |
-| trt_dla_enable                           | bool   | trt_dla_enable                        |                                         |
-| trt_dla_core                             | int    | trt_dla_core                          | e.g: 0                                  |
-| trt_engine_cache_enable                  | bool   | trt_engine_cache_enable               |                                         |
-| trt_engine_cache_path                    | string | trt_engine_cache_path                 |                                         |
-| trt_engine_cache_prefix                  | string | trt_engine_cache_prefix               |                                         |
-| trt_dump_subgraphs                       | bool   | trt_dump_subgraphs                    |                                         |
-| trt_force_sequential_engine_build        | bool   | trt_force_sequential_engine_build     |                                         |
-| trt_context_memory_sharing_enable        | bool   | trt_context_memory_sharing_enable     |                                         |
-| trt_layer_norm_fp32_fallback             | bool   | trt_layer_norm_fp32_fallback          |                                         |
-| trt_timing_cache_enable                  | bool   | trt_timing_cache_enable               |                                         |
-| trt_force_timing_cache                   | bool   | trt_force_timing_cache                |                                         |
-| trt_detailed_build_log                   | bool   | trt_detailed_build_log                |                                         |
-| trt_build_heuristics_enable              | bool   | trt_build_heuristics_enable           |                                         |
-| trt_sparsity_enable                      | bool   | trt_sparsity_enable                   |                                         |
-| trt_builder_optimization_level           | int    | trt_builder_optimization_level        | e.g: 3                                  |
-| trt_auxiliary_streams                    | int    | trt_auxiliary_streams                 | e.g: -1                                 |
-| trt_tactic_sources                       | string | trt_tactic_sources                    | e.g. “-CUDNN,+CUBLAS”                   |
-| trt_extra_plugin_lib_paths               | string | trt_extra_plugin_lib_paths            |                                         |
-| trt_profile_min_shapes                   | string | trt_profile_min_shapes                |                                         |
-| trt_profile_max_shapes                   | string | trt_profile_max_shapes                |                                         |
-| trt_profile_opt_shapes                   | string | trt_profile_opt_shapes                |                                         |
-| trt_cuda_graph_enable                    | bool   | trt_cuda_graph_enable                 |                                         |
+| Parameter: key in Triton model config | Parameter: value in Triton model config | Corresponding TensorRT EP option in ONNX Runtime | Type   |
+| ------------------------------------- | --------------------------------------- | :----------------------------------------------- | :----- |
+| max_workspace_size_bytes              | e.g: "4294967296"                       | trt_max_workspace_size                           | int    |
+| trt_max_partition_iterations          | e.g: "1000"                             | trt_max_partition_iterations                     | int    |
+| trt_min_subgraph_size                 | e.g: "1"                                | trt_min_subgraph_size                            | int    |
+| precision_mode                        | "FP16"                                  | trt_fp16_enable                                  | bool   |
+| precision_mode                        | "INT8"                                  | trt_int8_enable                                  | bool   |
+| int8_calibration_table_name           |                                         | trt_int8_calibration_table_name                  | string |
+| int8_calibration_table_name           |                                         | trt_int8_use_native_calibration_table            | bool   |
+| trt_dla_enable                        |                                         | trt_dla_enable                                   | bool   |
+| trt_dla_core                          | e.g: "0"                                | trt_dla_core                                     | int    |
+| trt_engine_cache_enable               |                                         | trt_engine_cache_enable                          | bool   |
+| trt_engine_cache_path                 |                                         | trt_engine_cache_path                            | string |
+| trt_engine_cache_prefix               |                                         | trt_engine_cache_prefix                          | string |
+| trt_dump_subgraphs                    |                                         | trt_dump_subgraphs                               | bool   |
+| trt_force_sequential_engine_build     |                                         | trt_force_sequential_engine_build                | bool   |
+| trt_context_memory_sharing_enable     |                                         | trt_context_memory_sharing_enable                | bool   |
+| trt_layer_norm_fp32_fallback          |                                         | trt_layer_norm_fp32_fallback                     | bool   |
+| trt_timing_cache_enable               |                                         | trt_timing_cache_enable                          | bool   |
+| trt_force_timing_cache                |                                         | trt_force_timing_cache                           | bool   |
+| trt_detailed_build_log                |                                         | trt_detailed_build_log                           | bool   |
+| trt_build_heuristics_enable           |                                         | trt_build_heuristics_enable                      | bool   |
+| trt_sparsity_enable                   |                                         | trt_sparsity_enable                              | bool   |
+| trt_builder_optimization_level        | e.g: "3"                                | trt_builder_optimization_level                   | int    |
+| trt_auxiliary_streams                 | e.g: "-1"                               | trt_auxiliary_streams                            | int    |
+| trt_tactic_sources                    | e.g. "-CUDNN,+CUBLAS"                   | trt_tactic_sources                               | string |
+| trt_extra_plugin_lib_paths            |                                         | trt_extra_plugin_lib_paths                       | string |
+| trt_profile_min_shapes                |                                         | trt_profile_min_shapes                           | string |
+| trt_profile_max_shapes                |                                         | trt_profile_max_shapes                           | string |
+| trt_profile_opt_shapes                |                                         | trt_profile_opt_shapes                           | string |
+| trt_cuda_graph_enable                 |                                         | trt_cuda_graph_enable                            | bool   |
+
 The section of model config file specifying these parameters will look like:
 
 ```

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -435,7 +435,7 @@ ModelState::LoadModel(
               // create tensorrt options with default values
               OrtTensorRTProviderOptionsV2* trt_options;
               THROW_IF_BACKEND_MODEL_ORT_ERROR(
-                 ort_api->CreateTensorRTProviderOptions(&trt_options));
+                  ort_api->CreateTensorRTProviderOptions(&trt_options));
               std::string int8_calibration_table_name;
               std::string trt_engine_cache_path;
               // Validate and set parameters
@@ -504,15 +504,15 @@ ModelState::LoadModel(
               }
 
               std::unique_ptr<
-                 OrtTensorRTProviderOptionsV2,
-                 decltype(ort_api->ReleaseTensorRTProviderOptions)>
-                 rel_trt_options(
-                    tensorrt_options, 
-                    ort_api->ReleaseTensorRTProviderOptions);
+                  OrtTensorRTProviderOptionsV2,
+                  decltype(ort_api->ReleaseTensorRTProviderOptions)>
+                  rel_trt_options(
+                      tensorrt_options,
+                      ort_api->ReleaseTensorRTProviderOptions);
               RETURN_IF_ORT_ERROR(
                   ort_api->SessionOptionsAppendExecutionProvider_TensorRT_V2(
-                     static_cast<OrtSessionOptions*>(soptions),
-                     rel_trt_options.get()));
+                      static_cast<OrtSessionOptions*>(soptions),
+                      rel_trt_options.get()));
               RETURN_IF_ORT_ERROR(
                   ort_api->SessionOptionsAppendExecutionProvider_TensorRT(
                       soptions, &trt_options));

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -473,6 +473,22 @@ ModelState::LoadModel(
                         value_string, &max_workspace_size_bytes));
                     key = "trt_max_workspace_size";
                     value = value_string;
+                  } else if (param_key == "trt_max_partition_iterations") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    int trt_max_partition_iterations;
+                    RETURN_IF_ERROR(ParseIntValue(
+                        value_string, &trt_max_partition_iterations));
+                    key = "trt_max_partition_iterations";
+                    value = value_string;
+                  } else if (param_key == "trt_min_subgraph_size") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    int trt_min_subgraph_size;
+                    RETURN_IF_ERROR(
+                        ParseIntValue(value_string, &trt_min_subgraph_size));
+                    key = "trt_min_subgraph_size";
+                    value = value_string;
                   } else if (param_key == "int8_calibration_table_name") {
                     RETURN_IF_ERROR(
                         params.MemberAsString(param_key.c_str(), &value));
@@ -484,6 +500,21 @@ ModelState::LoadModel(
                     RETURN_IF_ERROR(ParseBoolValue(
                         value_string, &use_native_calibration_table));
                     key = "trt_int8_use_native_calibration_table";
+                    value = value_string;
+                  } else if (param_key == "trt_dla_enable") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    bool trt_dla_enable;
+                    RETURN_IF_ERROR(
+                        ParseBoolValue(value_string, &trt_dla_enable));
+                    key = "trt_dla_enable";
+                    value = value_string;
+                  } else if (param_key == "trt_dla_core") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    int trt_dla_core;
+                    RETURN_IF_ERROR(ParseIntValue(value_string, &trt_dla_core));
+                    key = "trt_dla_core";
                     value = value_string;
                   } else if (param_key == "trt_engine_cache_enable") {
                     RETURN_IF_ERROR(params.MemberAsString(
@@ -497,14 +528,10 @@ ModelState::LoadModel(
                     RETURN_IF_ERROR(
                         params.MemberAsString(param_key.c_str(), &value));
                     key = "trt_engine_cache_path";
-                  } else if (param_key == "trt_timing_cache_enable") {
-                    RETURN_IF_ERROR(params.MemberAsString(
-                        param_key.c_str(), &value_string));
-                    bool enable_cache;
+                  } else if (param_key == "trt_engine_cache_prefix") {
                     RETURN_IF_ERROR(
-                        ParseBoolValue(value_string, &enable_cache));
-                    key = "trt_timing_cache_enable";
-                    value = value_string;
+                        params.MemberAsString(param_key.c_str(), &value));
+                    key = "trt_engine_cache_prefix";
                   } else if (param_key == "trt_dump_subgraphs") {
                     RETURN_IF_ERROR(params.MemberAsString(
                         param_key.c_str(), &value_string));
@@ -513,9 +540,114 @@ ModelState::LoadModel(
                         ParseBoolValue(value_string, &dump_subgraphs));
                     key = "trt_dump_subgraphs";
                     value = value_string;
+                  } else if (param_key == "trt_force_sequential_engine_build") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    bool trt_force_sequential_engine_build;
+                    RETURN_IF_ERROR(ParseBoolValue(
+                        value_string, &trt_force_sequential_engine_build));
+                    key = "trt_force_sequential_engine_build";
+                    value = value_string;
+                  } else if (param_key == "trt_context_memory_sharing_enable") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    bool trt_context_memory_sharing_enable;
+                    RETURN_IF_ERROR(ParseBoolValue(
+                        value_string, &trt_context_memory_sharing_enable));
+                    key = "trt_context_memory_sharing_enable";
+                    value = value_string;
+                  } else if (param_key == "trt_layer_norm_fp32_fallback") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    bool trt_layer_norm_fp32_fallback;
+                    RETURN_IF_ERROR(ParseBoolValue(
+                        value_string, &trt_layer_norm_fp32_fallback));
+                    key = "trt_layer_norm_fp32_fallback";
+                    value = value_string;
+                  } else if (param_key == "trt_timing_cache_enable") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    bool trt_timing_cache_enable;
+                    RETURN_IF_ERROR(
+                        ParseBoolValue(value_string, &trt_timing_cache_enable));
+                    key = "trt_timing_cache_enable";
+                    value = value_string;
+                  } else if (param_key == "trt_force_timing_cache") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    bool trt_force_timing_cache;
+                    RETURN_IF_ERROR(
+                        ParseBoolValue(value_string, &trt_force_timing_cache));
+                    key = "trt_force_timing_cache";
+                    value = value_string;
+                  } else if (param_key == "trt_detailed_build_log") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    bool trt_detailed_build_log;
+                    RETURN_IF_ERROR(
+                        ParseBoolValue(value_string, &trt_detailed_build_log));
+                    key = "trt_detailed_build_log";
+                    value = value_string;
+                  } else if (param_key == "trt_build_heuristics_enable") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    bool trt_build_heuristics_enable;
+                    RETURN_IF_ERROR(ParseBoolValue(
+                        value_string, &trt_build_heuristics_enable));
+                    key = "trt_build_heuristics_enable";
+                    value = value_string;
+                  } else if (param_key == "trt_sparsity_enable") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    bool trt_sparsity_enable;
+                    RETURN_IF_ERROR(
+                        ParseBoolValue(value_string, &trt_sparsity_enable));
+                    key = "trt_sparsity_enable";
+                    value = value_string;
+                  } else if (param_key == "trt_builder_optimization_level") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    int trt_builder_optimization_level;
+                    RETURN_IF_ERROR(ParseIntValue(
+                        value_string, &trt_builder_optimization_level));
+                    key = "trt_builder_optimization_level";
+                    value = value_string;
+                  } else if (param_key == "trt_auxiliary_streams") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    int trt_auxiliary_streams;
+                    RETURN_IF_ERROR(
+                        ParseIntValue(value_string, &trt_auxiliary_streams));
+                    key = "trt_auxiliary_streams";
+                    value = value_string;
+                  } else if (param_key == "trt_tactic_sources") {
                     RETURN_IF_ERROR(
                         params.MemberAsString(param_key.c_str(), &value));
-                    key = "trt_engine_cache_path";
+                    key = "trt_tactic_sources";
+                  } else if (param_key == "trt_extra_plugin_lib_paths") {
+                    RETURN_IF_ERROR(
+                        params.MemberAsString(param_key.c_str(), &value));
+                    key = "trt_extra_plugin_lib_paths";
+                  } else if (param_key == "trt_profile_min_shapes") {
+                    RETURN_IF_ERROR(
+                        params.MemberAsString(param_key.c_str(), &value));
+                    key = "trt_profile_min_shapes";
+                  } else if (param_key == "trt_profile_max_shapes") {
+                    RETURN_IF_ERROR(
+                        params.MemberAsString(param_key.c_str(), &value));
+                    key = "trt_profile_max_shapes";
+                  } else if (param_key == "trt_profile_opt_shapes") {
+                    RETURN_IF_ERROR(
+                        params.MemberAsString(param_key.c_str(), &value));
+                    key = "trt_profile_opt_shapes";
+                  } else if (param_key == "trt_cuda_graph_enable") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    bool trt_cuda_graph_enable;
+                    RETURN_IF_ERROR(
+                        ParseBoolValue(value_string, &trt_cuda_graph_enable));
+                    key = "trt_cuda_graph_enable";
+                    value = value_string;
                   } else {
                     return TRITONSERVER_ErrorNew(
                         TRITONSERVER_ERROR_INVALID_ARG,

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -41,6 +41,7 @@
 
 #ifdef TRITON_ENABLE_GPU
 #include <cuda_runtime_api.h>
+#include <tensorrt_provider_options.h>
 #endif  // TRITON_ENABLE_GPU
 
 //

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -528,6 +528,12 @@ ModelState::LoadModel(
                     values.push_back(value.c_str());
                   }
                 }
+                for (const char* str : keys) {
+                  std::cout << str << std::endl;
+                }
+                for (const char* str : values) {
+                  std::cout << str << std::endl;
+                }
                 if (!keys.empty() && !values.empty()) {
                     RETURN_IF_ORT_ERROR(ort_api->UpdateTensorRTProviderOptions(
                         rel_trt_options.get(), keys.data(), values.data(),

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -572,10 +572,6 @@ ModelState::LoadModel(
                         ParseBoolValue(value_string, &trt_timing_cache_enable));
                     key = "trt_timing_cache_enable";
                     value = value_string;
-                  } else if (param_key == "trt_timing_cache_path") {
-                    RETURN_IF_ERROR(
-                        params.MemberAsString(param_key.c_str(), &value));
-                    key = "trt_timing_cache_path";
                   } else if (param_key == "trt_force_timing_cache") {
                     RETURN_IF_ERROR(params.MemberAsString(
                         param_key.c_str(), &value_string));

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -648,6 +648,26 @@ ModelState::LoadModel(
                         ParseBoolValue(value_string, &trt_cuda_graph_enable));
                     key = "trt_cuda_graph_enable";
                     value = value_string;
+                  } else if (param_key == "trt_dump_ep_context_model") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    bool trt_dump_ep_context_model;
+                    RETURN_IF_ERROR(ParseBoolValue(
+                        value_string, &trt_dump_ep_context_model));
+                    key = "trt_dump_ep_context_model";
+                    value = value_string;
+                  } else if (param_key == "trt_ep_context_file_path") {
+                    RETURN_IF_ERROR(
+                        params.MemberAsString(param_key.c_str(), &value));
+                    key = "trt_ep_context_file_path";
+                  } else if (param_key == "trt_ep_context_embed_mode") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    int trt_ep_context_embed_mode;
+                    RETURN_IF_ERROR(ParseIntValue(
+                        value_string, &trt_ep_context_embed_mode));
+                    key = "trt_ep_context_embed_mode";
+                    value = value_string;
                   } else {
                     return TRITONSERVER_ErrorNew(
                         TRITONSERVER_ERROR_INVALID_ARG,

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -508,8 +508,7 @@ ModelState::LoadModel(
                   OrtTensorRTProviderOptionsV2,
                   decltype(ort_api->ReleaseTensorRTProviderOptions)>
                   rel_trt_options(
-                      trt_options,
-                      ort_api->ReleaseTensorRTProviderOptions);
+                      trt_options, ort_api->ReleaseTensorRTProviderOptions);
               RETURN_IF_ORT_ERROR(
                   ort_api->SessionOptionsAppendExecutionProvider_TensorRT_V2(
                       static_cast<OrtSessionOptions*>(soptions),

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -572,6 +572,10 @@ ModelState::LoadModel(
                         ParseBoolValue(value_string, &trt_timing_cache_enable));
                     key = "trt_timing_cache_enable";
                     value = value_string;
+                  } else if (param_key == "trt_timing_cache_path") {
+                    RETURN_IF_ERROR(
+                        params.MemberAsString(param_key.c_str(), &value));
+                    key = "trt_timing_cache_path";
                   } else if (param_key == "trt_force_timing_cache") {
                     RETURN_IF_ERROR(params.MemberAsString(
                         param_key.c_str(), &value_string));

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -451,6 +451,7 @@ ModelState::LoadModel(
                 RETURN_IF_ERROR(params.Members(&param_keys));
                 for (const auto& param_key : param_keys) {
                   std::string value_string, key, value;
+                  std::cout << param_key << std::endl;
                   if (param_key == "precision_mode") {
                     RETURN_IF_ERROR(params.MemberAsString(
                         param_key.c_str(), &value_string));
@@ -525,6 +526,7 @@ ModelState::LoadModel(
                   }
                   if (!key.empty() && !value.empty()) {
                     keys.push_back(key.c_str());
+                    std::cout << "push_back<-" << key << ": " << value << std::endl;
                     values.push_back(value.c_str());
                   }
                 }

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -450,7 +450,6 @@ ModelState::LoadModel(
                 RETURN_IF_ERROR(params.Members(&param_keys));
                 for (const auto& param_key : param_keys) {
                   std::string value_string, key, value;
-                  std::cout << param_key << std::endl;
                   if (param_key == "precision_mode") {
                     RETURN_IF_ERROR(params.MemberAsString(
                         param_key.c_str(), &value_string));
@@ -525,25 +524,22 @@ ModelState::LoadModel(
                   }
                   if (!key.empty() && !value.empty()) {
                     keys.push_back(key);
-                    std::cout << "push_back<-" << key << ": " << value << std::endl;
                     values.push_back(value);
                   }
                 }
-                std::cout << "keys.size()=" << keys.size() << " and values.size()=" << values.size() << std::endl;
                 std::vector<const char*> c_keys, c_values;
-                
+
                 if (!keys.empty() && !values.empty()) {
-                    for (size_t i = 0; i < keys.size(); ++i) {
-                        std::cout << keys[i] << ": " << values[i] << std::endl;
-                        c_keys.push_back(keys[i].c_str());
-                        c_values.push_back(values[i].c_str());
-                    }
-                    RETURN_IF_ORT_ERROR(ort_api->UpdateTensorRTProviderOptions(
-                        rel_trt_options.get(), c_keys.data(), c_values.data(),
-                        keys.size()));
+                  for (size_t i = 0; i < keys.size(); ++i) {
+                    c_keys.push_back(keys[i].c_str());
+                    c_values.push_back(values[i].c_str());
+                  }
+                  RETURN_IF_ORT_ERROR(ort_api->UpdateTensorRTProviderOptions(
+                      rel_trt_options.get(), c_keys.data(), c_values.data(),
+                      keys.size()));
                 }
               }
-              
+
               RETURN_IF_ORT_ERROR(
                   ort_api->SessionOptionsAppendExecutionProvider_TensorRT_V2(
                       static_cast<OrtSessionOptions*>(soptions),

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -530,11 +530,9 @@ ModelState::LoadModel(
                     values.push_back(value.c_str());
                   }
                 }
-                for (const char* str : keys) {
-                  std::cout << str << std::endl;
-                }
-                for (const char* str : values) {
-                  std::cout << str << std::endl;
+                std::cout << "keys.size()=" << keys.size() << " and values.size()=" << values.size() << std::endl;
+                for (size_t i = 0; i < keys.size(); ++i) {
+                  std::cout << keys[i] << ": " << values[i] << std::endl;
                 }
                 if (!keys.empty() && !values.empty()) {
                     RETURN_IF_ORT_ERROR(ort_api->UpdateTensorRTProviderOptions(

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -434,7 +434,8 @@ ModelState::LoadModel(
             if (name == kTensorRTExecutionAccelerator) {
               // create tensorrt options with default values
               OrtTensorRTProviderOptionsV2* trt_options;
-              THROW_IF_BACKEND_MODEL_ORT_ERROR(ort_api->CreateTensorRTProviderOptions(&trt_options));
+              THROW_IF_BACKEND_MODEL_ORT_ERROR(
+                 ort_api->CreateTensorRTProviderOptions(&trt_options));
               std::string int8_calibration_table_name;
               std::string trt_engine_cache_path;
               // Validate and set parameters
@@ -502,12 +503,16 @@ ModelState::LoadModel(
                 }
               }
 
-              std::unique_ptr<OrtTensorRTProviderOptionsV2, decltype(ort_api->ReleaseTensorRTProviderOptions)> rel_trt_options(
-                 tensorrt_options, ort_api->ReleaseTensorRTProviderOptions);
+              std::unique_ptr<
+                 OrtTensorRTProviderOptionsV2,
+                 decltype(ort_api->ReleaseTensorRTProviderOptions)>
+                 rel_trt_options(
+                    tensorrt_options, 
+                    ort_api->ReleaseTensorRTProviderOptions);
               RETURN_IF_ORT_ERROR(
                   ort_api->SessionOptionsAppendExecutionProvider_TensorRT_V2(
-                      static_cast<OrtSessionOptions*>(soptions),
-                                                        rel_trt_options.get()));
+                     static_cast<OrtSessionOptions*>(soptions),
+                     rel_trt_options.get()));
               RETURN_IF_ORT_ERROR(
                   ort_api->SessionOptionsAppendExecutionProvider_TensorRT(
                       soptions, &trt_options));

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -41,7 +41,6 @@
 
 #ifdef TRITON_ENABLE_GPU
 #include <cuda_runtime_api.h>
-#include <tensorrt_provider_options.h>
 #endif  // TRITON_ENABLE_GPU
 
 //
@@ -457,10 +456,10 @@ ModelState::LoadModel(
                         param_key.c_str(), &value_string));
                     if (value_string == "FP16") {
                       key = "trt_fp16_enable";
-                      value = "1"
+                      value = "1";
                     } else if (value_string == "INT8") {
                       key = "trt_int8_enable";
-                      value = "1"
+                      value = "1";
                     } else if (value_string != "FP32") {
                       RETURN_ERROR_IF_FALSE(
                           false, TRITONSERVER_ERROR_INVALID_ARG,
@@ -476,15 +475,15 @@ ModelState::LoadModel(
                     key = "trt_max_workspace_size";
                     value = value_string;
                   } else if (param_key == "int8_calibration_table_name") {
-                    RETURN_IF_ERROR(params.MemberAsString(
-                        param_key.c_str(), &value));
+                    RETURN_IF_ERROR(
+                       params.MemberAsString(param_key.c_str(), &value));
                     key = "trt_int8_calibration_table_name";
                   } else if (param_key == "int8_use_native_calibration_table") {
                     RETURN_IF_ERROR(params.MemberAsString(
                         param_key.c_str(), &value_string));
                     bool use_native_calibration_table;
                     RETURN_IF_ERROR(ParseBoolValue(
-                       value_string, &use_native_calibration_table));
+                        value_string, &use_native_calibration_table));
                     key = "trt_int8_use_native_calibration_table";
                     value = value_string;
                   } else if (param_key == "trt_engine_cache_enable") {
@@ -496,7 +495,8 @@ ModelState::LoadModel(
                     key = "trt_engine_cache_enable";
                     value = value_string;
                   } else if (param_key == "trt_engine_cache_path") {
-                    RETURN_IF_ERROR(params.MemberAsString(param_key.c_str(), &value));
+                    RETURN_IF_ERROR(
+                       params.MemberAsString(param_key.c_str(), &value));
                     key = "trt_engine_cache_path";
                   } else {
                     return TRITONSERVER_ErrorNew(
@@ -512,7 +512,7 @@ ModelState::LoadModel(
                 }
                 ort_api->UpdateTensorRTProviderOptions(
                     rel_trt_options.get(), keys.data(), values.data(),
-                    keys.size())
+                    keys.size());
               }
               
               RETURN_IF_ORT_ERROR(

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -449,9 +449,9 @@ ModelState::LoadModel(
                     RETURN_IF_ERROR(params.MemberAsString(
                         param_key.c_str(), &value_string));
                     if (value_string == "FP16") {
-                      trt_options.trt_fp16_enable = 1;
+                      trt_options->trt_fp16_enable = 1;
                     } else if (value_string == "INT8") {
-                      trt_options.trt_int8_enable = 1;
+                      trt_options->trt_int8_enable = 1;
                     } else if (value_string != "FP32") {
                       RETURN_ERROR_IF_FALSE(
                           false, TRITONSERVER_ERROR_INVALID_ARG,
@@ -464,12 +464,12 @@ ModelState::LoadModel(
                     size_t max_workspace_size_bytes;
                     RETURN_IF_ERROR(ParseUnsignedLongLongValue(
                         value_string, &max_workspace_size_bytes));
-                    trt_options.trt_max_workspace_size =
+                    trt_options->trt_max_workspace_size =
                         max_workspace_size_bytes;
                   } else if (param_key == "int8_calibration_table_name") {
                     RETURN_IF_ERROR(params.MemberAsString(
                         param_key.c_str(), &int8_calibration_table_name));
-                    trt_options.trt_int8_calibration_table_name =
+                    trt_options->trt_int8_calibration_table_name =
                         int8_calibration_table_name.c_str();
                   } else if (param_key == "int8_use_native_calibration_table") {
                     RETURN_IF_ERROR(params.MemberAsString(
@@ -477,7 +477,7 @@ ModelState::LoadModel(
                     int use_native_calibration_table;
                     RETURN_IF_ERROR(ParseIntValue(
                         value_string, &use_native_calibration_table));
-                    trt_options.trt_int8_use_native_calibration_table =
+                    trt_options->trt_int8_use_native_calibration_table =
                         use_native_calibration_table;
                   } else if (param_key == "trt_engine_cache_enable") {
                     RETURN_IF_ERROR(params.MemberAsString(
@@ -485,11 +485,11 @@ ModelState::LoadModel(
                     bool enable_cache;
                     RETURN_IF_ERROR(
                         ParseBoolValue(value_string, &enable_cache));
-                    trt_options.trt_engine_cache_enable = enable_cache;
+                    trt_options->trt_engine_cache_enable = enable_cache;
                   } else if (param_key == "trt_engine_cache_path") {
                     RETURN_IF_ERROR(params.MemberAsString(
                         param_key.c_str(), &trt_engine_cache_path));
-                    trt_options.trt_engine_cache_path =
+                    trt_options->trt_engine_cache_path =
                         trt_engine_cache_path.c_str();
                   } else {
                     return TRITONSERVER_ErrorNew(
@@ -507,15 +507,12 @@ ModelState::LoadModel(
                   OrtTensorRTProviderOptionsV2,
                   decltype(ort_api->ReleaseTensorRTProviderOptions)>
                   rel_trt_options(
-                      tensorrt_options,
+                      trt_options,
                       ort_api->ReleaseTensorRTProviderOptions);
               RETURN_IF_ORT_ERROR(
                   ort_api->SessionOptionsAppendExecutionProvider_TensorRT_V2(
                       static_cast<OrtSessionOptions*>(soptions),
                       rel_trt_options.get()));
-              RETURN_IF_ORT_ERROR(
-                  ort_api->SessionOptionsAppendExecutionProvider_TensorRT(
-                      soptions, &trt_options));
               LOG_MESSAGE(
                   TRITONSERVER_LOG_VERBOSE,
                   (std::string("TensorRT Execution Accelerator is set for '") +

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -498,6 +498,22 @@ ModelState::LoadModel(
                     RETURN_IF_ERROR(
                         params.MemberAsString(param_key.c_str(), &value));
                     key = "trt_engine_cache_path";
+                  } else if (param_key == "trt_timing_cache_enable") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    bool enable_cache;
+                    RETURN_IF_ERROR(
+                        ParseBoolValue(value_string, &enable_cache));
+                    key = "trt_timing_cache_enable";
+                    value = value_string;
+                  } else if (param_key == "trt_dump_subgraphs") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    bool dump_subgraphs;
+                    RETURN_IF_ERROR(
+                        ParseBoolValue(value_string, &dump_subgraphs));
+                    key = "trt_dump_subgraphs";
+                    value = value_string;
                   } else {
                     return TRITONSERVER_ErrorNew(
                         TRITONSERVER_ERROR_INVALID_ARG,
@@ -512,8 +528,8 @@ ModelState::LoadModel(
                 }
                 RETURN_IF_ORT_ERROR(
                     ort_api->UpdateTensorRTProviderOptions(
-                        rel_trt_options.get(), keys.data(), values.data(),
-                        keys.size()));
+                    rel_trt_options.get(), keys.data(), values.data(),
+                    keys.size()));
               }
               
               RETURN_IF_ORT_ERROR(

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -476,7 +476,7 @@ ModelState::LoadModel(
                     value = value_string;
                   } else if (param_key == "int8_calibration_table_name") {
                     RETURN_IF_ERROR(
-                       params.MemberAsString(param_key.c_str(), &value));
+                        params.MemberAsString(param_key.c_str(), &value));
                     key = "trt_int8_calibration_table_name";
                   } else if (param_key == "int8_use_native_calibration_table") {
                     RETURN_IF_ERROR(params.MemberAsString(
@@ -496,7 +496,7 @@ ModelState::LoadModel(
                     value = value_string;
                   } else if (param_key == "trt_engine_cache_path") {
                     RETURN_IF_ERROR(
-                       params.MemberAsString(param_key.c_str(), &value));
+                        params.MemberAsString(param_key.c_str(), &value));
                     key = "trt_engine_cache_path";
                   } else {
                     return TRITONSERVER_ErrorNew(
@@ -510,9 +510,10 @@ ModelState::LoadModel(
                   keys.push_back(key.c_str());
                   values.push_back(value.c_str());
                 }
-                ort_api->UpdateTensorRTProviderOptions(
-                    rel_trt_options.get(), keys.data(), values.data(),
-                    keys.size());
+                RETURN_IF_ORT_ERROR(
+                    ort_api->UpdateTensorRTProviderOptions(
+                        rel_trt_options.get(), keys.data(), values.data(),
+                        keys.size()));
               }
               
               RETURN_IF_ORT_ERROR(

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -512,7 +512,7 @@ ModelState::LoadModel(
                   ort_api->SessionOptionsAppendExecutionProvider_TensorRT(
                       soptions, &trt_options));
               LOG_MESSAGE(
-                  TRITONSERVER_LOG_INFO,
+                  TRITONSERVER_LOG_VERBOSE,
                   (std::string("TensorRT Execution Accelerator is set for '") +
                    Name() + "' on device " +
                    std::to_string(instance_group_device_id))

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -523,13 +523,16 @@ ModelState::LoadModel(
                             "Accelerator")
                             .c_str());
                   }
-                  keys.push_back(key.c_str());
-                  values.push_back(value.c_str());
+                  if (!key.empty() && !value.empty()) {
+                    keys.push_back(key.c_str());
+                    values.push_back(value.c_str());
+                  }
                 }
-                RETURN_IF_ORT_ERROR(
-                    ort_api->UpdateTensorRTProviderOptions(
-                    rel_trt_options.get(), keys.data(), values.data(),
-                    keys.size()));
+                if (!keys.empty() && !values.empty()) {
+                    RETURN_IF_ORT_ERROR(ort_api->UpdateTensorRTProviderOptions(
+                        rel_trt_options.get(), keys.data(), values.data(),
+                        keys.size()));
+                }
               }
               
               RETURN_IF_ORT_ERROR(

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -446,8 +446,7 @@ ModelState::LoadModel(
               // Validate and set parameters
               triton::common::TritonJson::Value params;
               if (ea.Find("parameters", &params)) {
-                std::vector<std::string> param_keys;
-                std::vector<const char*> keys, values;
+                std::vector<std::string> param_keys, keys, values;
                 RETURN_IF_ERROR(params.Members(&param_keys));
                 for (const auto& param_key : param_keys) {
                   std::string value_string, key, value;
@@ -525,18 +524,22 @@ ModelState::LoadModel(
                             .c_str());
                   }
                   if (!key.empty() && !value.empty()) {
-                    keys.push_back(key.c_str());
+                    keys.push_back(key);
                     std::cout << "push_back<-" << key << ": " << value << std::endl;
-                    values.push_back(value.c_str());
+                    values.push_back(value);
                   }
                 }
                 std::cout << "keys.size()=" << keys.size() << " and values.size()=" << values.size() << std::endl;
-                for (size_t i = 0; i < keys.size(); ++i) {
-                  std::cout << keys[i] << ": " << values[i] << std::endl;
-                }
+                std::vector<const char*> c_keys, c_values;
+                
                 if (!keys.empty() && !values.empty()) {
+                    for (size_t i = 0; i < keys.size(); ++i) {
+                        std::cout << keys[i] << ": " << values[i] << std::endl;
+                        c_keys.push_back(keys[i].c_str());
+                        c_values.push_back(values[i].c_str());
+                    }
                     RETURN_IF_ORT_ERROR(ort_api->UpdateTensorRTProviderOptions(
-                        rel_trt_options.get(), keys.data(), values.data(),
+                        rel_trt_options.get(), c_keys.data(), c_values.data(),
                         keys.size()));
                 }
               }


### PR DESCRIPTION
This PR enables more ORT-TRTEP v2 options:

| trt_max_partition_iterations          |
| :------------------------------------ |
| trt_min_subgraph_size                 |
| trt_dla_enable                        |
| trt_dla_core                          |
| trt_engine_cache_prefix               |
| trt_dump_subgraphs                    |
| trt_force_sequential_engine_build     |
| trt_context_memory_sharing_enable     |
| trt_layer_norm_fp32_fallback          |
| trt_timing_cache_enable               |
| trt_force_timing_cache                |
| trt_detailed_build_log                |
| trt_build_heuristics_enable           |
| trt_sparsity_enable                   |
| trt_builder_optimization_level        |
| trt_auxiliary_streams                 |
| trt_tactic_sources                    |
| trt_extra_plugin_lib_paths            |
| trt_profile_min_shapes                |
| trt_profile_max_shapes                |
| trt_profile_opt_shapes                |
| trt_cuda_graph_enable                 |
| trt_cuda_graph_enable                 |
| trt_dump_ep_context_model        |
| trt_ep_context_file_path              | 
| trt_ep_context_embed_mode      |

Check [updated README](https://github.com/triton-inference-server/onnxruntime_backend/blob/8aeb6332138ff0931989688bafdb55426246f698/README.md#onnx-runtime-with-tensorrt-optimization) for more detail