### PR TITLE
Add support for sharing an ORT session

### DIFF
--- a/src/onnxruntime_utils.cc
+++ b/src/onnxruntime_utils.cc
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "onnxruntime_utils.h"
+#include <regex>
 
 namespace triton { namespace backend { namespace onnxruntime {
 
@@ -550,5 +551,23 @@ CompareDimsSupported(
   return nullptr;  // success
 }
 
+std::string
+GetInstanceGroupName(
+    const std::string& model_name, const std::string& instance_name)
+{
+  if (model_name.empty() || instance_name.empty()) {
+    return "";
+  }
+  // Using regex search to extract instance group name from model instance name
+  // model instance naming follows pattern: <model name>_<instance group index>_<instance index>
+  // instance group naming follows pattern: <model name>_<instance group index>
+  std::regex group_name_regex('(' + model_name + '_' + "[0-9]" + ')');
+  std::smatch group_name;
+  if (std::regex_search(instance_name, group_name, group_name_regex)) {
+    return group_name.str(1);
+  }
+
+  return "";
+}
 
 }}}  // namespace triton::backend::onnxruntime

--- a/src/onnxruntime_utils.h
+++ b/src/onnxruntime_utils.h
@@ -157,4 +157,7 @@ TRITONSERVER_Error* CompareDimsSupported(
     const std::vector<int64_t>& model_shape, const std::vector<int64_t>& dims,
     const int max_batch_size, const bool compare_exact);
 
+std::string GetInstanceGroupName(
+    const std::string& model_name, const std::string& instance_name);
+
 }}}  // namespace triton::backend::onnxruntime


### PR DESCRIPTION
For every instance in a model instance group a new ORT session is created. This code adds support to share a session per instance group.
This support can be enabled by defining
'share_session_between_instances' to true
in triton model config "parameters". Example:
parameters [
.....
  {
    key: "share_session_between_instances"
    value: {string_value: "true"}
  }
]

This is a global parameter and cannot be defined per instance group. The user should determine if the parameter makes sense for their setup.

When log-info option of tritonserver is set to "1", the logs will indicate that a session is mapped for the instance group during the first initialized instance and reused for other instances.
Example:
 TRITONBACKEND_ModelInstanceInitialize: <model>_0_1 (CPU device 0)
 TRITONBACKEND_ModelInstanceInitialize: <model>_0_0 (CPU device 0)
 Could not find a session corresponding to instance group: <model>_0
 Created session for instance: <model>_0_1
 Mapped session for instance group: <model>_0
 Reusing session for instance: <model>_0_0

Change-Id: I6dc509b9c2451e3dd14d45f6f150b37f50b5db89