### PR TITLE
Remove openvino hard-coded versioning in onnxruntime backend build

### DIFF
--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -783,7 +783,7 @@ ModelState::LoadModel(
               need_lock = true;
               OrtOpenVINOProviderOptions openvino_options;
               openvino_options.device_type =
-                  "CPU_FP32";  // device_type default is CPU_FP32
+                  "CPU";  // device_type default is CPU
 
               RETURN_IF_ORT_ERROR(
                   ort_api->SessionOptionsAppendExecutionProvider_OpenVINO(

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -44,10 +44,6 @@ ORT_TO_TRTPARSER_VERSION_MAP = {
 }
 
 OPENVINO_VERSION_MAP = {
-    "2023.3.0": (
-        "2023.3",  # OpenVINO short version
-        "2023.3.0.13775.ceeafaf64f3",  # OpenVINO version with build number
-    ),
     "2024.0.0": (
         "2024.0",  # OpenVINO short version
         "2024.0.0.14509.34caeefd078",  # OpenVINO version with build number
@@ -165,9 +161,6 @@ RUN curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/$
 
 # Step 2: Configure the environment
 # Ref: https://docs.openvino.ai/2024/get-started/install-openvino/install-openvino-archive-linux.html#step-2-configure-the-environment
-# `InferenceEngine_DIR` and `ngraph_DIR` are required only for OV 2023.3.0. Can be removed for 2024.0.0 and above.
-ENV InferenceEngine_DIR=$INTEL_OPENVINO_DIR/runtime/cmake
-ENV ngraph_DIR=$INTEL_OPENVINO_DIR/runtime/cmake
 ENV OpenVINO_DIR=$INTEL_OPENVINO_DIR/runtime/cmake
 ENV LD_LIBRARY_PATH $INTEL_OPENVINO_DIR/runtime/lib/intel64:$LD_LIBRARY_PATH
 ENV PKG_CONFIG_PATH=$INTEL_OPENVINO_DIR/runtime/lib/intel64/pkgconfig

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -40,6 +40,21 @@ ORT_TO_TRTPARSER_VERSION_MAP = {
     "1.10.0": (
         "8.2",  # TensorRT version
         "release/8.2-GA",  # ONNX-Tensorrt parser version
+    ),
+}
+
+OPENVINO_VERSION_MAP = {
+    "2023.3.0": (
+        "2023.3",  # OpenVINO short version
+        "2023.3.0.13775.ceeafaf64f3",  # OpenVINO version with build number
+    ),
+    "2024.0.0": (
+        "2024.0",  # OpenVINO short version
+        "2024.0.0.14509.34caeefd078",  # OpenVINO version with build number
+    ),
+    "2024.1.0": (
+        "2024.1",  # OpenVINO short version
+        "2024.1.0.15008.f4afc983258",  # OpenVINO version with build number
     ),
 }
 
@@ -127,20 +142,29 @@ RUN _CUDNN_VERSION=$(echo $CUDNN_VERSION | cut -d. -f1-2) && \
 # Install OpenVINO
 ARG ONNXRUNTIME_OPENVINO_VERSION
 ENV INTEL_OPENVINO_DIR /opt/intel/openvino_${ONNXRUNTIME_OPENVINO_VERSION}
+"""
+        df += """
+ARG OPENVINO_SHORT_VERSION={}
+ARG OPENVINO_VERSION_WITH_BUILD_NUMBER={}
+""".format(
+            OPENVINO_VERSION_MAP[FLAGS.ort_openvino][0],
+            OPENVINO_VERSION_MAP[FLAGS.ort_openvino][1],
+        )
 
+        df += """
 # Step 1: Download and install core components
-# Ref: https://docs.openvino.ai/2023.3/openvino_docs_install_guides_installing_openvino_from_archive_linux.html#step-1-download-and-install-the-openvino-core-components
-RUN curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/2023.3/linux/l_openvino_toolkit_ubuntu22_2023.3.0.13775.ceeafaf64f3_x86_64.tgz --output openvino_${ONNXRUNTIME_OPENVINO_VERSION}.tgz && \
+# Ref: https://docs.openvino.ai/2024/get-started/install-openvino/install-openvino-archive-linux.html#step-1-download-and-install-the-openvino-core-components
+RUN curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/${OPENVINO_SHORT_VERSION}/linux/l_openvino_toolkit_ubuntu22_${OPENVINO_VERSION_WITH_BUILD_NUMBER}_x86_64.tgz --output openvino_${ONNXRUNTIME_OPENVINO_VERSION}.tgz && \
     tar -xf openvino_${ONNXRUNTIME_OPENVINO_VERSION}.tgz && \
     mkdir -p ${INTEL_OPENVINO_DIR} && \
-    mv l_openvino_toolkit_ubuntu22_2023.3.0.13775.ceeafaf64f3_x86_64/* ${INTEL_OPENVINO_DIR} && \
+    mv l_openvino_toolkit_ubuntu22_${OPENVINO_VERSION_WITH_BUILD_NUMBER}_x86_64/* ${INTEL_OPENVINO_DIR} && \
     rm openvino_${ONNXRUNTIME_OPENVINO_VERSION}.tgz && \
     (cd ${INTEL_OPENVINO_DIR}/install_dependencies && \
         ./install_openvino_dependencies.sh -y) && \
     ln -s ${INTEL_OPENVINO_DIR} ${INTEL_OPENVINO_DIR}/../openvino_`echo ${ONNXRUNTIME_OPENVINO_VERSION} | awk '{print substr($0,0,4)}'`
 
 # Step 2: Configure the environment
-# Ref: https://docs.openvino.ai/2023.3/openvino_docs_install_guides_installing_openvino_from_archive_linux.html#step-2-configure-the-environment
+# Ref: https://docs.openvino.ai/2024/get-started/install-openvino/install-openvino-archive-linux.html#step-2-configure-the-environment
 ENV InferenceEngine_DIR=$INTEL_OPENVINO_DIR/runtime/cmake
 ENV ngraph_DIR=$INTEL_OPENVINO_DIR/runtime/cmake
 ENV OpenVINO_DIR=$INTEL_OPENVINO_DIR/runtime/cmake

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -246,7 +246,7 @@ RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnx
             ep_flags += " --allow_running_as_root"
 
     if FLAGS.ort_openvino is not None:
-        ep_flags += " --use_openvino CPU_FP32"
+        ep_flags += " --use_openvino CPU"
 
     if target_platform() == "igpu":
         ep_flags += (
@@ -440,7 +440,7 @@ RUN git clone -b rel-%ONNXRUNTIME_VERSION% --recursive %ONNXRUNTIME_REPO% onnxru
             if FLAGS.tensorrt_home is not None:
                 ep_flags += ' --tensorrt_home "{}"'.format(FLAGS.tensorrt_home)
     if FLAGS.ort_openvino is not None:
-        ep_flags += " --use_openvino CPU_FP32"
+        ep_flags += " --use_openvino CPU"
 
     df += """
 WORKDIR /workspace/onnxruntime

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -165,6 +165,7 @@ RUN curl -L https://storage.openvinotoolkit.org/repositories/openvino/packages/$
 
 # Step 2: Configure the environment
 # Ref: https://docs.openvino.ai/2024/get-started/install-openvino/install-openvino-archive-linux.html#step-2-configure-the-environment
+# `InferenceEngine_DIR` and `ngraph_DIR` are required only for OV 2023.3.0. Can be removed for 2024.0.0 and above.
 ENV InferenceEngine_DIR=$INTEL_OPENVINO_DIR/runtime/cmake
 ENV ngraph_DIR=$INTEL_OPENVINO_DIR/runtime/cmake
 ENV OpenVINO_DIR=$INTEL_OPENVINO_DIR/runtime/cmake
@@ -179,43 +180,40 @@ ENV PYTHONPATH $INTEL_OPENVINO_DIR/python/python3.10:$INTEL_OPENVINO_DIR/python/
     # From ORT 1.9 onwards we will switch back to using rel-* branches
     if FLAGS.ort_version == "1.8.1":
         df += """
-    #
-    # ONNX Runtime build
-    #
-    ARG ONNXRUNTIME_VERSION
-    ARG ONNXRUNTIME_REPO
-    ARG ONNXRUNTIME_BUILD_CONFIG
+#
+# ONNX Runtime build
+#
+ARG ONNXRUNTIME_VERSION
+ARG ONNXRUNTIME_REPO
+ARG ONNXRUNTIME_BUILD_CONFIG
 
-    RUN git clone -b tensorrt-8.0 --recursive ${ONNXRUNTIME_REPO} onnxruntime && \
-        (cd onnxruntime && git submodule update --init --recursive)
-
+RUN git clone -b tensorrt-8.0 --recursive ${ONNXRUNTIME_REPO} onnxruntime && \
+    (cd onnxruntime && git submodule update --init --recursive)
        """
     # Use the tensorrt-8.5ea branch to use Tensor RT 8.5a to use the built-in tensorrt parser
     elif FLAGS.ort_version == "1.12.1":
         df += """
-    #
-    # ONNX Runtime build
-    #
-    ARG ONNXRUNTIME_VERSION
-    ARG ONNXRUNTIME_REPO
-    ARG ONNXRUNTIME_BUILD_CONFIG
+#
+# ONNX Runtime build
+#
+ARG ONNXRUNTIME_VERSION
+ARG ONNXRUNTIME_REPO
+ARG ONNXRUNTIME_BUILD_CONFIG
 
-    RUN git clone -b tensorrt-8.5ea --recursive ${ONNXRUNTIME_REPO} onnxruntime && \
-        (cd onnxruntime && git submodule update --init --recursive)
-
+RUN git clone -b tensorrt-8.5ea --recursive ${ONNXRUNTIME_REPO} onnxruntime && \
+    (cd onnxruntime && git submodule update --init --recursive)
        """
     else:
         df += """
-    #
-    # ONNX Runtime build
-    #
-    ARG ONNXRUNTIME_VERSION
-    ARG ONNXRUNTIME_REPO
-    ARG ONNXRUNTIME_BUILD_CONFIG
+#
+# ONNX Runtime build
+#
+ARG ONNXRUNTIME_VERSION
+ARG ONNXRUNTIME_REPO
+ARG ONNXRUNTIME_BUILD_CONFIG
 
-    RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime && \
-        (cd onnxruntime && git submodule update --init --recursive)
-
+RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime && \
+    (cd onnxruntime && git submodule update --init --recursive)
         """
 
     if FLAGS.onnx_tensorrt_tag != "":


### PR DESCRIPTION
Tested with OV 2024.X. This PR should be merged after ORT upgraded to 1.18.