### PR TITLE
enhancement: Dynamically updating CUDA EP options

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ $ make install
 
 
 ## ONNX Runtime with TensorRT optimization
-TensorRT can be used in conjunction with an ONNX model to further optimize the performance. To enable TensorRT optimization you must set the model configuration appropriately. There are several optimizations available for TensorRT, like selection of the compute precision and workspace size. The optimization parameters and their description are as follows.
+TensorRT can be used in conjunction with an ONNX model to further optimize the
+performance. To enable TensorRT optimization you must set the model configuration
+appropriately. There are several optimizations available for TensorRT, like
+selection of the compute precision and workspace size. The optimization
+parameters and their description are as follows.
 
 
 * `precision_mode`: The precision used for optimization. Allowed values are "FP32", "FP16" and "INT8". Default value is "FP32".
@@ -93,9 +97,11 @@ TensorRT can be used in conjunction with an ONNX model to further optimize the p
 * `trt_engine_cache_enable`: Enable engine caching.
 * `trt_engine_cache_path`: Specify engine cache path.
 
-To explore the usage of more parameters, follow the mapping table below and check [ONNX Runtime doc](https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#execution-provider-options) for detail.
+To explore the usage of more parameters, follow the mapping table below and
+check [ONNX Runtime doc](https://onnxruntime.ai/docs/execution-providers/TensorRT-ExecutionProvider.html#execution-provider-options) for detail.
 
-> Please link to the latest ONNX Runtime binaries in CMake or build from [main branch of ONNX Runtime](https://github.com/microsoft/onnxruntime/tree/main) to enable latest options.
+> Please link to the latest ONNX Runtime binaries in CMake or build from
+[main branch of ONNX Runtime](https://github.com/microsoft/onnxruntime/tree/main) to enable latest options.
 
 ### Parameter mapping between ONNX Runtime and Triton ONNXRuntime Backend
 
@@ -155,7 +161,15 @@ optimization { execution_accelerators {
 ```
 
 ## ONNX Runtime with CUDA Execution Provider optimization
-When GPU is enabled for ORT, CUDA execution provider is enabled. If TensorRT is also enabled then CUDA EP is treated as a fallback option (only comes into picture for nodes which TensorRT cannot execute). If TensorRT is not enabled then CUDA EP is the primary EP which executes the models. ORT enabled configuring options for CUDA EP to further optimize based on the specific model and user scenarios. There are several optimizations available, please refer to the [ONNX Runtime doc](https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#cuda-execution-provider) for more details. To enable CUDA EP optimization you must set the model configuration appropriately:
+When GPU is enabled for ORT, CUDA execution provider is enabled. If TensorRT is
+also enabled then CUDA EP is treated as a fallback option (only comes into
+picture for nodes which TensorRT cannot execute). If TensorRT is not enabled
+then CUDA EP is the primary EP which executes the models. ORT enabled
+configuring options for CUDA EP to further optimize based on the specific model
+and user scenarios. There are several optimizations available, please refer to
+the [ONNX Runtime doc](https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#cuda-execution-provider)
+for more details. To enable CUDA EP optimization you must set the model
+configuration appropriately:
 
 ```
 optimization { execution_accelerators {
@@ -168,15 +182,27 @@ optimization { execution_accelerators {
 ```
 
 ### Deprecated Parameters
-The way to specify these specific parameters as shown below is deprecated. For backward compatibility, these parameters are still supported. Please use the above method to specify the parameters.
+The way to specify these specific parameters as shown below is deprecated. For
+backward compatibility, these parameters are still supported. Please use the
+above method to specify the parameters.
 
-* `cudnn_conv_algo_search`: CUDA Convolution algorithm search configuration. Available options are 0 - EXHAUSTIVE (expensive exhaustive benchmarking using cudnnFindConvolutionForwardAlgorithmEx). This is also the default option, 1 - HEURISTIC (lightweight heuristic based search using cudnnGetConvolutionForwardAlgorithm_v7), 2 - DEFAULT (default algorithm using CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM)
+* `cudnn_conv_algo_search`: CUDA Convolution algorithm search configuration.
+Available options are 0 - EXHAUSTIVE (expensive exhaustive benchmarking using
+cudnnFindConvolutionForwardAlgorithmEx). This is also the default option,
+1 - HEURISTIC (lightweight heuristic based search using
+cudnnGetConvolutionForwardAlgorithm_v7), 2 - DEFAULT (default algorithm using
+CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM)
 
-* `gpu_mem_limit`: CUDA memory limit. To use all possible memory pass in maximum size_t. Defaults to SIZE_MAX.
+* `gpu_mem_limit`: CUDA memory limit. To use all possible memory pass in maximum
+size_t. Defaults to SIZE_MAX.
 
-* `arena_extend_strategy`: Strategy used to grow the memory arena. Available options are: 0 = kNextPowerOfTwo, 1 = kSameAsRequested. Defaults to 0.
+* `arena_extend_strategy`: Strategy used to grow the memory arena. Available
+options are: 0 = kNextPowerOfTwo, 1 = kSameAsRequested. Defaults to 0.
 
-* `do_copy_in_default_stream`: Flag indicating if copying needs to take place on the same stream as the compute stream in the CUDA EP. Available options are: 0 = Use separate streams for copying and compute, 1 = Use the same stream for copying and compute. Defaults to 1.
+* `do_copy_in_default_stream`: Flag indicating if copying needs to take place on
+the same stream as the compute stream in the CUDA EP. Available options are:
+0 = Use separate streams for copying and compute, 1 = Use the same stream for
+copying and compute. Defaults to 1.
 
 In the model config file, specifying these parameters will look like:
 
@@ -216,14 +242,26 @@ optimization { execution_accelerators {
 
 ## Other Optimization Options with ONNX Runtime
 
-Details regarding when to use these options and what to expect from them can be found [here](https://onnxruntime.ai/docs/performance/tune-performance.html)
+Details regarding when to use these options and what to expect from them can be
+found [here](https://onnxruntime.ai/docs/performance/tune-performance.html)
 
 ### Model Config Options
-* `intra_op_thread_count`: Sets the number of threads used to parallelize the execution within nodes. A value of 0 means ORT will pick a default which is number of cores.
-* `inter_op_thread_count`: Sets the number of threads used to parallelize the execution of the graph (across nodes). If sequential execution is enabled this value is ignored.
+* `intra_op_thread_count`: Sets the number of threads used to parallelize the
+execution within nodes. A value of 0 means ORT will pick a default which is
+number of cores.
+* `inter_op_thread_count`: Sets the number of threads used to parallelize the
+execution of the graph (across nodes). If sequential execution is enabled this
+value is ignored.
 A value of 0 means ORT will pick a default which is number of cores.
-* `execution_mode`: Controls whether operators in the graph are executed sequentially or in parallel. Usually when the model has many branches, setting this option to 1 .i.e. "parallel" will give you better performance. Default is 0 which is "sequential execution."
-* `level`: Refers to the graph optimization level. By default all optimizations are enabled. Allowed values are -1, 1 and 2. -1 refers to BASIC optimizations, 1 refers to basic plus extended optimizations like fusions and 2 refers to all optimizations being disabled. Please find the details [here](https://onnxruntime.ai/docs/performance/graph-optimizations.html).
+* `execution_mode`: Controls whether operators in the graph are executed
+sequentially or in parallel. Usually when the model has many branches, setting
+this option to 1 .i.e. "parallel" will give you better performance. Default is
+0 which is "sequential execution."
+* `level`: Refers to the graph optimization level. By default all optimizations
+are enabled. Allowed values are -1, 1 and 2. -1 refers to BASIC optimizations,
+1 refers to basic plus extended optimizations like fusions and 2 refers to all
+optimizations being disabled. Please find the details
+[here](https://onnxruntime.ai/docs/performance/graph-optimizations.html).
 
 ```
 optimization {
@@ -236,15 +274,27 @@ parameters { key: "execution_mode" value: { string_value: "0" } }
 parameters { key: "inter_op_thread_count" value: { string_value: "0" } }
 
 ```
-* `enable_mem_arena`: Use 1 to enable the arena and 0 to disable. See [this](https://onnxruntime.ai/docs/api/c/struct_ort_api.html#a0bbd62df2b3c119636fba89192240593) for more information.
-* `enable_mem_pattern`: Use 1 to enable memory pattern and 0 to disable. See [this](https://onnxruntime.ai/docs/api/c/struct_ort_api.html#ad13b711736956bf0565fea0f8d7a5d75) for more information.
-* `memory.enable_memory_arena_shrinkage`: See [this](https://github.com/microsoft/onnxruntime/blob/master/include/onnxruntime/core/session/onnxruntime_run_options_config_keys.h) for more information.
+* `enable_mem_arena`: Use 1 to enable the arena and 0 to disable. See
+[this](https://onnxruntime.ai/docs/api/c/struct_ort_api.html#a0bbd62df2b3c119636fba89192240593)
+for more information.
+* `enable_mem_pattern`: Use 1 to enable memory pattern and 0 to disable.
+See [this](https://onnxruntime.ai/docs/api/c/struct_ort_api.html#ad13b711736956bf0565fea0f8d7a5d75)
+for more information.
+* `memory.enable_memory_arena_shrinkage`:
+See [this](https://github.com/microsoft/onnxruntime/blob/master/include/onnxruntime/core/session/onnxruntime_run_options_config_keys.h)
+for more information.
 
 ### Command line options
 
 #### Thread Pools
 
-When intra and inter op threads is set to 0 or a value higher than 1, by default ORT creates threadpool per session. This may not be ideal in every scenario, therefore ORT also supports global threadpools. When global threadpools are enabled ORT creates 1 global threadpool which is shared by every session. Use the backend config to enable global threadpool. When global threadpool is enabled, intra and inter op num threads config should also be provided via backend config. Config values provided in model config will be ignored.
+When intra and inter op threads is set to 0 or a value higher than 1, by default
+ORT creates threadpool per session. This may not be ideal in every scenario,
+therefore ORT also supports global threadpools. When global threadpools are
+enabled ORT creates 1 global threadpool which is shared by every session.
+Use the backend config to enable global threadpool. When global threadpool is
+enabled, intra and inter op num threads config should also be provided via
+backend config. Config values provided in model config will be ignored.
 
 ```
 --backend-config=onnxruntime,enable-global-threadpool=<0,1>, --backend-config=onnxruntime,intra_op_thread_count=<int> , --backend-config=onnxruntime,inter_op_thread_count=<int>
@@ -252,16 +302,20 @@ When intra and inter op threads is set to 0 or a value higher than 1, by default
 
 #### Default Max Batch Size
 
-The default-max-batch-size value is used for max_batch_size during [Autocomplete](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#auto-generated-model-configuration) when no
-other value is found. Assuming server was not launched with `--disable-auto-complete-config`
-command-line option, the onnxruntime backend will set the max_batch_size
-of the model to this default value under the following conditions:
+The default-max-batch-size value is used for max_batch_size during
+[Autocomplete](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#auto-generated-model-configuration)
+when no other value is found. Assuming server was not launched with
+`--disable-auto-complete-config` command-line option, the onnxruntime backend
+will set the max_batch_size of the model to this default value under the
+following conditions:
 
 1. Autocomplete has determined the model is capable of batching requests.
 2. max_batch_size is 0 in the model configuration or max_batch_size
    is omitted from the model configuration.
 
-If max_batch_size > 1 and no [scheduler](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#scheduling-and-batching) is provided, the dynamic batch scheduler will be used.
+If max_batch_size > 1 and no
+[scheduler](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#scheduling-and-batching)
+is provided, the dynamic batch scheduler will be used.
 
 ```
 --backend-config=onnxruntime,default-max-batch-size=<int>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-# Copyright (c) 2020-2023, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2020-2024, NVIDIA CORPORATION. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -155,7 +155,20 @@ optimization { execution_accelerators {
 ```
 
 ## ONNX Runtime with CUDA Execution Provider optimization
-When GPU is enabled for ORT, CUDA execution provider is enabled. If TensorRT is also enabled then CUDA EP is treated as a fallback option (only comes into picture for nodes which TensorRT cannot execute). If TensorRT is not enabled then CUDA EP is the primary EP which executes the models. ORT enabled configuring options for CUDA EP to further optimize based on the specific model and user scenarios. To enable CUDA EP optimization you must set the model configuration appropriately. There are several optimizations available, like selection of max mem, cudnn conv algorithm etc... The optimization parameters and their description are as follows.
+When GPU is enabled for ORT, CUDA execution provider is enabled. If TensorRT is also enabled then CUDA EP is treated as a fallback option (only comes into picture for nodes which TensorRT cannot execute). If TensorRT is not enabled then CUDA EP is the primary EP which executes the models. ORT enabled configuring options for CUDA EP to further optimize based on the specific model and user scenarios. There are several optimizations available, please refer to the [ONNX Runtime doc](https://onnxruntime.ai/docs/execution-providers/CUDA-ExecutionProvider.html#cuda-execution-provider) for more details. To enable CUDA EP optimization you must set the model configuration appropriately:
+
+```
+optimization { execution_accelerators {
+  gpu_execution_accelerator : [ {
+    name : "cuda"
+    parameters { key: "cudnn_conv_use_max_workspace" value: "0" }
+    parameters { key: "use_ep_level_unified_stream" value: "1" }}
+  ]
+}}
+```
+
+### Deprecated Parameters
+The way to specify these specific parameters as shown below is deprecated. For backward compatibility, these parameters are still supported. Please use the above method to specify the parameters.
 
 * `cudnn_conv_algo_search`: CUDA Convolution algorithm search configuration. Available options are 0 - EXHAUSTIVE (expensive exhaustive benchmarking using cudnnFindConvolutionForwardAlgorithmEx). This is also the default option, 1 - HEURISTIC (lightweight heuristic based search using cudnnGetConvolutionForwardAlgorithm_v7), 2 - DEFAULT (default algorithm using CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM)
 
@@ -165,7 +178,7 @@ When GPU is enabled for ORT, CUDA execution provider is enabled. If TensorRT is 
 
 * `do_copy_in_default_stream`: Flag indicating if copying needs to take place on the same stream as the compute stream in the CUDA EP. Available options are: 0 = Use separate streams for copying and compute, 1 = Use the same stream for copying and compute. Defaults to 1.
 
-The section of model config file specifying these parameters will look like:
+In the model config file, specifying these parameters will look like:
 
 ```
 .

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -1,4 +1,4 @@
-// Copyright 2019-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2019-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -419,6 +419,7 @@ ModelState::LoadModel(
 #ifdef TRITON_ENABLE_GPU
   if ((instance_group_kind == TRITONSERVER_INSTANCEGROUPKIND_GPU) ||
       (instance_group_kind == TRITONSERVER_INSTANCEGROUPKIND_AUTO)) {
+    std::map<std::string, std::string> cuda_options_map;
     triton::common::TritonJson::Value optimization;
     if (model_config_.Find("optimization", &optimization)) {
       triton::common::TritonJson::Value eas;
@@ -673,8 +674,13 @@ ModelState::LoadModel(
                     key = "trt_ep_context_embed_mode";
                     value = value_string;
                   } else {
-                    key = param_key;
-                    params.MemberAsString(param_key.c_str(), &value);
+                    return TRITONSERVER_ErrorNew(
+                        TRITONSERVER_ERROR_INVALID_ARG,
+                        std::string(
+                            "unknown parameter '" + param_key +
+                            "' is provided for TensorRT Execution "
+                            "Accelerator")
+                            .c_str());
                   }
                   if (!key.empty() && !value.empty()) {
                     keys.push_back(key);
@@ -687,25 +693,9 @@ ModelState::LoadModel(
                     c_keys.push_back(keys[i].c_str());
                     c_values.push_back(values[i].c_str());
                   }
-                  auto status = ort_api->UpdateTensorRTProviderOptions(
+                  RETURN_IF_ORT_ERROR(ort_api->UpdateTensorRTProviderOptions(
                       rel_trt_options.get(), c_keys.data(), c_values.data(),
-                      keys.size());
-                  if (status != nullptr) {
-                    OrtAllocator* allocator;
-                    char* options;
-                    RETURN_IF_ORT_ERROR(
-                        ort_api->GetAllocatorWithDefaultOptions(&allocator));
-                    RETURN_IF_ORT_ERROR(
-                        ort_api->GetTensorRTProviderOptionsAsString(
-                            rel_trt_options.get(), allocator, &options));
-                    return TRITONSERVER_ErrorNew(
-                        TRITONSERVER_ERROR_INVALID_ARG,
-                        (std::string("unknown parameters in config following "
-                                     "options are supported for TensorRT "
-                                     "Execution Provider: ") +
-                         std::string(options))
-                            .c_str());
-                  }
+                      keys.size()));
                 }
               }
 
@@ -722,11 +712,41 @@ ModelState::LoadModel(
               continue;
             }
 #endif  // TRITON_ENABLE_ONNXRUNTIME_TENSORRT
-            return TRITONSERVER_ErrorNew(
-                TRITONSERVER_ERROR_INVALID_ARG,
-                (std::string("unknown Execution Accelerator '") + name +
-                 "' is requested")
-                    .c_str());
+
+            if (name == "cuda") {
+              // Parse CUDA EP configurations
+              triton::common::TritonJson::Value params;
+              if (ea.Find("parameters", &params)) {
+                std::vector<std::string> param_keys;
+                RETURN_IF_ERROR(params.Members(&param_keys));
+                for (const auto& param_key : param_keys) {
+                  std::string value_string, key, value;
+                  // Special handling for boolean values
+                  if (param_key == "do_copy_in_default_stream" ||
+                      param_key == "use_ep_level_unified_stream") {
+                    RETURN_IF_ERROR(params.MemberAsString(
+                        param_key.c_str(), &value_string));
+                    bool bool_value;
+                    RETURN_IF_ERROR(ParseBoolValue(value_string, &bool_value));
+                    key = param_key;
+                    value = value_string;
+                  } else {
+                    key = param_key;
+                    RETURN_IF_ERROR(
+                        params.MemberAsString(param_key.c_str(), &value));
+                  }
+                  if (!key.empty() && !value.empty()) {
+                    cuda_options_map[key] = value;
+                  }
+                }
+              }
+            } else {
+              return TRITONSERVER_ErrorNew(
+                  TRITONSERVER_ERROR_INVALID_ARG,
+                  (std::string("unknown Execution Accelerator '") + name +
+                   "' is requested")
+                      .c_str());
+            }
           }
         }
       }
@@ -740,44 +760,99 @@ ModelState::LoadModel(
     std::unique_ptr<
         OrtCUDAProviderOptionsV2, decltype(ort_api->ReleaseCUDAProviderOptions)>
         rel_cuda_options(cuda_options, ort_api->ReleaseCUDAProviderOptions);
-    std::map<std::string, std::string> options;
-    options["device_id"] = std::to_string(instance_group_device_id);
+    cuda_options_map["device_id"] = std::to_string(instance_group_device_id);
+    cuda_options_map["has_user_compute_stream"] = stream != nullptr ? "1" : "0";
+    RETURN_IF_ORT_ERROR(ort_api->UpdateCUDAProviderOptionsWithValue(
+        rel_cuda_options.get(), "default_memory_arena_cfg", nullptr));
     {
-      // Parse CUDA EP configurations
+      // Parse CUDA EP configurations directly from the parameters field.
+      // This is deprecated with adding support for CUDA EP in the
+      // gpu_execution_accelerator field. Keeping this for backward
+      // compatibility.
       triton::common::TritonJson::Value params;
       if (model_config_.Find("parameters", &params)) {
-        std::vector<std::string> members;
-        RETURN_IF_ERROR(params.Members(&members));
-        for (auto& m : members) {
-          const auto [it_value, success] = options.insert({m, ""});
-          if (success) {
-            params.MemberAsString(m.c_str(), &it_value->second);
+        triton::common::TritonJson::Value json_value;
+        if (params.Find("cudnn_conv_algo_search", &json_value)) {
+          int cudnn_conv_algo_search = 0;
+          RETURN_IF_ERROR(TryParseModelStringParameter(
+              params, "cudnn_conv_algo_search", &cudnn_conv_algo_search, 0));
+          std::string string_value;
+          switch (cudnn_conv_algo_search) {
+            case 0:
+              string_value = "EXHAUSTIVE";
+              break;
+            case 1:
+              string_value = "HEURISTIC";
+              break;
+            case 2:
+              string_value = "DEFAULT";
+              break;
+            default:
+              return TRITONSERVER_ErrorNew(
+                  TRITONSERVER_ERROR_INVALID_ARG,
+                  (std::string("unsupported cudnn_conv_algo_search value '") +
+                   std::to_string(cudnn_conv_algo_search) + "' is requested")
+                      .c_str());
           }
+          cuda_options_map["cudnn_conv_algo_search"] = string_value;
+        } else {
+          cuda_options_map["cudnn_conv_algo_search"] = "EXHAUSTIVE";
+        }
+
+        if (params.Find("gpu_mem_limit", &json_value)) {
+          std::string string_value;
+          RETURN_IF_ERROR(
+              json_value.MemberAsString("string_value", &string_value));
+          cuda_options_map["gpu_mem_limit"] = string_value;
+        } else {
+          cuda_options_map["gpu_mem_limit"] =
+              std::to_string(std::numeric_limits<size_t>::max());
+        }
+
+        if (params.Find("arena_extend_strategy", &json_value)) {
+          int arena_extend_strategy = 0;
+          RETURN_IF_ERROR(TryParseModelStringParameter(
+              params, "arena_extend_strategy", &arena_extend_strategy, 0));
+          std::string string_value;
+          switch (arena_extend_strategy) {
+            case 0:
+              string_value = "kNextPowerOfTwo";
+              break;
+            case 1:
+              string_value = "kSameAsRequested";
+              break;
+            default:
+              return TRITONSERVER_ErrorNew(
+                  TRITONSERVER_ERROR_INVALID_ARG,
+                  (std::string("unsupported arena_extend_strategy value '") +
+                   std::to_string(arena_extend_strategy) + "' is requested")
+                      .c_str());
+          }
+          cuda_options_map["arena_extend_strategy"] = string_value;
+        } else {
+          cuda_options_map["arena_extend_strategy"] = "kNextPowerOfTwo";
+        }
+
+        if (params.Find("do_copy_in_default_stream", &json_value)) {
+          std::string string_value;
+          RETURN_IF_ERROR(
+              json_value.MemberAsString("string_value", &string_value));
+          cuda_options_map["do_copy_in_default_stream"] = string_value;
+        } else {
+          cuda_options_map["do_copy_in_default_stream"] = "1";
         }
       }
     }
 
     std::vector<const char*> option_names, option_values;
-    for (const auto& [key, value] : options) {
+    for (const auto& [key, value] : cuda_options_map) {
       option_names.push_back(key.c_str());
       option_values.push_back(value.c_str());
     }
-    auto status = ort_api->UpdateCUDAProviderOptions(
+
+    RETURN_IF_ORT_ERROR(ort_api->UpdateCUDAProviderOptions(
         rel_cuda_options.get(), option_names.data(), option_values.data(),
-        option_values.size());
-    if (status != nullptr) {
-      OrtAllocator* allocator;
-      char* options;
-      RETURN_IF_ORT_ERROR(ort_api->GetAllocatorWithDefaultOptions(&allocator));
-      RETURN_IF_ORT_ERROR(ort_api->GetCUDAProviderOptionsAsString(
-          rel_cuda_options.get(), allocator, &options));
-      return TRITONSERVER_ErrorNew(
-          TRITONSERVER_ERROR_INVALID_ARG,
-          (std::string("unknown parameters in config following options are "
-                       "supported for CUDA Execution Provider: ") +
-           std::string(options))
-              .c_str());
-    }
+        option_values.size()));
 
     if (stream != nullptr) {
       RETURN_IF_ORT_ERROR(ort_api->UpdateCUDAProviderOptionsWithValue(
@@ -785,10 +860,17 @@ ModelState::LoadModel(
     }
     RETURN_IF_ORT_ERROR(ort_api->SessionOptionsAppendExecutionProvider_CUDA_V2(
         soptions, cuda_options));
+
+    OrtAllocator* allocator;
+    char* options;
+    RETURN_IF_ORT_ERROR(ort_api->GetAllocatorWithDefaultOptions(&allocator));
+    RETURN_IF_ORT_ERROR(ort_api->GetCUDAProviderOptionsAsString(
+        rel_cuda_options.get(), allocator, &options));
     LOG_MESSAGE(
         TRITONSERVER_LOG_VERBOSE,
         (std::string("CUDA Execution Accelerator is set for '") + Name() +
-         "' on device " + std::to_string(instance_group_device_id))
+         "' on device " + std::to_string(instance_group_device_id) +
+         std::string(" with options: ") + std::string(options))
             .c_str());
   }
 #endif  // TRITON_ENABLE_GPU


### PR DESCRIPTION
This PR is based on https://github.com/triton-inference-server/onnxruntime_backend/pull/242 to add the flexibility to allow users to provide CUDA EP options in a flexible fashion. Note that this PR doesn't include the update for TRT options.

Before, the CUDA EP options are set within the parameters field:
```
...
parameters { key: "cudnn_conv_algo_search" value: { string_value: "0" } }
parameters { key: "gpu_mem_limit" value: { string_value: "4294967200" } }
...
```
After this enhancement, users are able to set any kinds of CUDA EP options just like the TRT EP:
```
optimization { execution_accelerators {
  gpu_execution_accelerator : [ {
    name : "cuda"
    parameters { key: "cudnn_conv_use_max_workspace" value: "0" }
    parameters { key: "use_ep_level_unified_stream" value: "1" }}
  ]
}}
```

For backward compatibility, setting CUDA EP options within the parameters field should still work.

Related PRs:
https://github.com/triton-inference-server/backend/pull/100
https://github.com/triton-inference-server/core/pull/368
Testing: https://github.com/triton-inference-server/server/pull/7328