### PR TITLE
fix: Fix ORT backend memory leak

### DIFF
--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -872,6 +872,7 @@ ModelState::LoadModel(
          "' on device " + std::to_string(instance_group_device_id) +
          std::string(" with options: ") + std::string(options))
             .c_str());
+    ort_api->AllocatorFree(allocator, options);
   }
 #endif  // TRITON_ENABLE_GPU
 

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -872,7 +872,7 @@ ModelState::LoadModel(
          "' on device " + std::to_string(instance_group_device_id) +
          std::string(" with options: ") + std::string(options))
             .c_str());
-    ort_api->AllocatorFree(allocator, options);
+    RETURN_IF_ORT_ERROR(ort_api->AllocatorFree(allocator, options));
   }
 #endif  // TRITON_ENABLE_GPU
 


### PR DESCRIPTION
Added the missing `ort_api->AllocatorFree` to avoid memory leaks.

Before the fix, there will be memory leaks whenever GPU is enabled and ORT backend is using CUDA execution provider by default. This happens during model loading:
```
==1947== 399 bytes in 1 blocks are definitely lost in loss record 1,355 of 1,950
[2450](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2450)==1947== at 0x484DE30: memalign (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
[2451](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2451)==1947== by 0x484DF92: posix_memalign (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
[2452](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2452)==1947== by 0x56E7EDF4: onnxruntime::AllocatorDefaultAlloc(unsigned long) (in /opt/tritonserver/backends/onnxruntime/libonnxruntime.so)
[2453](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2453)==1947== by 0x566498C8: onnxruntime::StrDup(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, OrtAllocator*) (in /opt/tritonserver/backends/onnxruntime/libonnxruntime.so)
[2454](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2454)==1947== by 0x566761DE: OrtApis::GetCUDAProviderOptionsAsString(OrtCUDAProviderOptionsV2 const*, OrtAllocator*, char**) (in /opt/tritonserver/backends/onnxruntime/libonnxruntime.so)
[2455](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2455)==1947== by 0x27DEED0F: triton::backend::onnxruntime::ModelState::LoadModel(std::{}cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, TRITONSERVER_instancegroupkind_enum, int, std::{_}_cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, OrtSession, OrtAllocator, CUstream_st) (in /opt/tritonserver/backends/onnxruntime/libtriton_onnxruntime.so)
[2456](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2456)==1947== by 0x27DF3807: triton::backend::onnxruntime::ModelInstanceState::ModelInstanceState(triton::backend::onnxruntime::ModelState*, TRITONBACKEND_ModelInstance*) (in /opt/tritonserver/backends/onnxruntime/libtriton_onnxruntime.so)
[2457](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2457)==1947== by 0x27DF46A1: triton::backend::onnxruntime::ModelInstanceState::Create(triton::backend::onnxruntime::ModelState*, TRITONBACKEND_ModelInstance*, triton::backend::onnxruntime::ModelInstanceState**) (in /opt/tritonserver/backends/onnxruntime/libtriton_onnxruntime.so)
[2458](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2458)==1947== by 0x27DF4ED5: TRITONBACKEND_ModelInstanceInitialize (in /opt/tritonserver/backends/onnxruntime/libtriton_onnxruntime.so)
[2459](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2459)==1947== by 0x51B441E: triton::core::TritonModelInstance::ConstructAndInitializeInstance(triton::core::TritonModel*, std::{}cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, triton::core::TritonModelInstance::Signature const&, TRITONSERVER_instancegroupkind_enum, int, std::vector<std::{}cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::{}cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, std::{}cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::map<std::{}cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::{}cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::{}cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::{}cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::{_}_cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > > const&, inference::ModelRateLimiter const&, std::vector<triton::core::TritonModelInstance::SecondaryDevice, std::allocator<triton::core::TritonModelInstance::SecondaryDevice> > const&, std::shared_ptr<triton::core::TritonModelInstance>*) (in /opt/tritonserver/lib/libtritonserver.so)
[2460](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2460)==1947== by 0x51B5666: triton::core::TritonModelInstance::CreateInstance(triton::core::TritonModel*, std::{}cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, triton::core::TritonModelInstance::Signature const&, TRITONSERVER_instancegroupkind_enum, int, std::vector<std::{}cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::{}cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool, std::{_}_cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, inference::ModelRateLimiter const&, std::vector<triton::core::TritonModelInstance::SecondaryDevice, std::allocator<triton::core::TritonModelInstance::SecondaryDevice> > const&, std::shared_ptr<triton::core::TritonModelInstance>*) (in /opt/tritonserver/lib/libtritonserver.so)
[2461](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2461)==1947== by 0x5197724: triton::core::TritonModel::PrepareInstances(inference::ModelConfig const&, std::vector<std::shared_ptr<triton::core::TritonModelInstance>, std::allocator<std::shared_ptr<triton::core::TritonModelInstance> > >, std::vector<std::shared_ptr<triton::core::TritonModelInstance>, std::allocator<std::shared_ptr<triton::core::TritonModelInstance> > >)::{lambda()#1}::operator()() const (in /opt/tritonserver/lib/libtritonserver.so)
[2462](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2462)==1947== by 0x5197D75: std::Function_handler<std::unique_ptr<std::future_base::_Result_base, std::future_base::_Result_base::_Deleter> (), std::future_base::_Task_setter<std::unique_ptr<std::future_base::_Result<triton::core::Status>, std::_future_base::_Result_base::_Deleter>, std::thread::_Invoker<std::tuple<triton::core::TritonModel::PrepareInstances(inference::ModelConfig const&, std::vector<std::shared_ptr<triton::core::TritonModelInstance>, std::allocator<std::shared_ptr<triton::core::TritonModelInstance> > >, std::vector<std::shared_ptr<triton::core::TritonModelInstance>, std::allocator<std::shared_ptr<triton::core::TritonModelInstance> > >)::{lambda()#1}> >, triton::core::Status> >::_M_invoke(std::_Any_data const&) (in /opt/tritonserver/lib/libtritonserver.so)
[2463](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2463)==1947== by 0x51A46EC: std::{}future_base::State_baseV2::_M_do_set(std::function<std::unique_ptr<std::future_base::_Result_base, std::_future_base::_Result_base::_Deleter> ()>, bool) (in /opt/tritonserver/lib/libtritonserver.so)
[2464](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2464)==1947== by 0x6BA0EE7: __pthread_once_slow (pthread_once.c:116)
[2465](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2465)==1947== by 0x518F80D: std::__future_base::_Async_state_impl<std::thread::_Invoker<std::tuple<triton::core::TritonModel::PrepareInstances(inference::ModelConfig const&, std::vector<std::shared_ptr<triton::core::TritonModelInstance>, std::allocator<std::shared_ptr<triton::core::TritonModelInstance> > >, std::vector<std::shared_ptr<triton::core::TritonModelInstance>, std::allocator<std::shared_ptr<triton::core::TritonModelInstance> > >)::{lambda()#1}> >, triton::core::Status>::_M_run() (in /opt/tritonserver/lib/libtritonserver.so)
[2466](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2466)==1947== by 0x69B7252: ??? (in /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.30)
[2467](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2467)==1947== by 0x6B9BAC2: start_thread (pthread_create.c:442)
[2468](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2468)==1947== by 0x6C2CA03: clone (clone.S:100)
[2469](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2469)***
[2470](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/98519216#L2470)*** Test Failed: 1 leaks detected.

```