### PR TITLE
fix: Fix ORT backend memory leak (#261)

### DIFF
--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -872,6 +872,7 @@ ModelState::LoadModel(
          "' on device " + std::to_string(instance_group_device_id) +
          std::string(" with options: ") + std::string(options))
             .c_str());
+    RETURN_IF_ORT_ERROR(ort_api->AllocatorFree(allocator, options));
   }
 #endif  // TRITON_ENABLE_GPU
 


### PR DESCRIPTION
Cherry-picking for r24.07.

* Call AllocatorFree

* Handle return