### PR TITLE
build: RHEL8 PyTorch Backend

### DIFF
--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -109,7 +109,6 @@ ENV PYBIN=${PYTHONPATH}/bin
 ENV PYTHON_BIN_PATH=${PYBIN}/python${PYVER} \
     PATH=${PYBIN}:${PATH}
 
-RUN yum check-update || true
 RUN yum install -y \
         wget \
         zip \

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -122,7 +122,7 @@ RUN yum install -y \
         openssl-devel
 
 """
-    else: 
+    else:
         df += """
 
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -94,6 +94,38 @@ ENV DEBIAN_FRONTEND=noninteractive
 # The Onnx Runtime dockerfile is the collection of steps in
 # https://github.com/microsoft/onnxruntime/tree/master/dockerfiles
 
+"""
+    # Consider moving rhel logic to its own function e.g., dockerfile_for_rhel
+    # if the changes become more substantial.
+    if target_platform() == "rhel":
+        df += """
+# The manylinux container defaults to Python 3.7, but some feature installation
+# requires a higher version.
+ARG PYVER=3.10
+ENV PYTHONPATH=/opt/python/v
+RUN ln -sf /opt/python/cp${PYVER/./}* ${PYTHONPATH}
+
+ENV PYBIN=${PYTHONPATH}/bin
+ENV PYTHON_BIN_PATH=${PYBIN}/python${PYVER} \
+    PATH=${PYBIN}:${PATH}
+
+RUN yum check-update || true
+RUN yum install -y \
+        wget \
+        zip \
+        ca-certificates \
+        curl \
+        patchelf \
+        python3-pip \
+        git \
+        gnupg \
+        gnupg1 \
+        openssl-devel
+
+"""
+    else: 
+        df += """
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
         software-properties-common \
         wget \


### PR DESCRIPTION
Goal: Support the ORT Backend on RHEL8 systems.

Server Changes: https://github.com/triton-inference-server/server/pull/7568
TensorRT Backend: https://github.com/triton-inference-server/tensorrt_backend/pull/98
TensorFlow: https://github.com/triton-inference-server/tensorflow_backend/pull/105
PyTorch Backend: https://github.com/triton-inference-server/pytorch_backend/pull/137