### PR TITLE
hardcoding sym link library reference for ONNX

### DIFF
--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -383,7 +383,8 @@ RUN OV_SHORT_VERSION=`echo ${ONNXRUNTIME_OPENVINO_VERSION} | awk '{ split($0,a,"
     # Linking compiled ONNX Runtime libraries to their corresponding versioned libraries
     df += """
 RUN cd /opt/onnxruntime/lib \
-        && ln -s libonnxruntime.so libonnxruntime.so.${ONNXRUNTIME_VERSION}
+        && ln -s libonnxruntime.so libonnxruntime.so.1 \
+        && ln -s libonnxruntime.so.1 libonnxruntime.so.${ONNXRUNTIME_VERSION}
 """
     df += """
 RUN cd /opt/onnxruntime/lib && \


### PR DESCRIPTION
Hard coding by using symbolic link to point to the missed library in ONNX backend.
Ref: https://nvidia.slack.com/archives/CJN9422C9/p1723748846373309

Verified that this change is required for ORT version 1.19.2.
Example pipeline [here](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/pipelines/18139020)

PS: This change required for ONNX versions 1.19.1 and 1.19.2. 
