### PR TITLE
Define missed CUDA architectures for non x86_64 builds. (#318)

### DIFF
--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -323,7 +323,9 @@ RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnx
         else:
             cuda_archs = "87"
     else:
-        if os.getenv("CUDA_ARCH_LIST") is not None:
+        if os.uname().machine != "x86_64":
+            cuda_archs = "80;86;90;100;110;120;121"
+        elif os.getenv("CUDA_ARCH_LIST") is not None:
             print(f"[INFO] Defined CUDA_ARCH_LIST: {os.getenv('CUDA_ARCH_LIST')}")
             cuda_archs = (
                 os.getenv("CUDA_ARCH_LIST")


### PR DESCRIPTION
* Enable all-major CUDA architectures for non x86_64 builds.

* Hardcoding the value

Fixes TRI-30