### PR TITLE
feat: add support for custom OpenVINO execution provider parameters

### DIFF
--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -286,28 +286,6 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
     }
 
     {
-      triton::common::TritonJson::Value params;
-      if (ModelConfig().Find("parameters", &params)) {
-        triton::common::TritonJson::Value json_value;
-        const char* intra_op_allow_spinning_key =
-            "session.intra_op.allow_spinning";
-        if (params.Find(intra_op_allow_spinning_key, &json_value)) {
-          std::string string_value;
-          THROW_IF_BACKEND_MODEL_ERROR(
-              json_value.MemberAsString("string_value", &string_value));
-
-          LOG_MESSAGE(
-              TRITONSERVER_LOG_VERBOSE,
-              (std::string("Configuring '") + intra_op_allow_spinning_key +
-               "' to '" + string_value + "' for '" + Name() + "'")
-                  .c_str());
-          THROW_IF_BACKEND_MODEL_ORT_ERROR(ort_api->AddSessionConfigEntry(
-              soptions, intra_op_allow_spinning_key, string_value.c_str()));
-        }
-      }
-    }
-
-    {
       // Sets the number of threads used to parallelize the execution of the
       // graph (across nodes) If sequential execution is enabled this value is
       // ignored A value of 0 means ORT will pick a default
@@ -322,51 +300,36 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
             ort_api->SetInterOpNumThreads(soptions, inter_op_thread_count));
       }
     }
-
-    {
-      triton::common::TritonJson::Value params;
-      if (ModelConfig().Find("parameters", &params)) {
-        triton::common::TritonJson::Value json_value;
-        const char* inter_op_allow_spinning_key =
-            "session.inter_op.allow_spinning";
-        if (params.Find(inter_op_allow_spinning_key, &json_value)) {
-          std::string string_value;
-          THROW_IF_BACKEND_MODEL_ERROR(
-              json_value.MemberAsString("string_value", &string_value));
-
-          LOG_MESSAGE(
-              TRITONSERVER_LOG_VERBOSE,
-              (std::string("Configuring '") + inter_op_allow_spinning_key +
-               "' to '" + string_value + "' for '" + Name() + "'")
-                  .c_str());
-          THROW_IF_BACKEND_MODEL_ORT_ERROR(ort_api->AddSessionConfigEntry(
-              soptions, inter_op_allow_spinning_key, string_value.c_str()));
-        }
-      }
-    }
   }
 
-  // Enable/disable use_device_allocator_for_initializers
+  // Iterate over all 'session.' prefixed parameters and add them via AddSessionConfigEntry
+  // This covers parameters that were previously manually added, such as:
+  // - session.intra_op.allow_spinning
+  // - session.inter_op.allow_spinning
+  // - session.force_spinning_stop
+  // - session.use_device_allocator_for_initializers
   {
     triton::common::TritonJson::Value params;
     if (ModelConfig().Find("parameters", &params)) {
-      triton::common::TritonJson::Value json_value;
-      const char* use_device_allocator_for_initializers_key =
-          "session.use_device_allocator_for_initializers";
-      if (params.Find(use_device_allocator_for_initializers_key, &json_value)) {
-        std::string string_value;
-        THROW_IF_BACKEND_MODEL_ERROR(
-            json_value.MemberAsString("string_value", &string_value));
+      std::vector<std::string> param_keys;
+      THROW_IF_BACKEND_MODEL_ERROR(params.Members(&param_keys));
+      for (const auto& param_key : param_keys) {
+        if (param_key.rfind("session.", 0) == 0) {
+          triton::common::TritonJson::Value json_value;
+          if (params.Find(param_key.c_str(), &json_value)) {
+            std::string string_value;
+            THROW_IF_BACKEND_MODEL_ERROR(
+                json_value.MemberAsString("string_value", &string_value));
 
-        LOG_MESSAGE(
-            TRITONSERVER_LOG_VERBOSE,
-            (std::string("Configuring '") +
-             use_device_allocator_for_initializers_key + "' to '" +
-             string_value + "' for '" + Name() + "'")
-                .c_str());
-        THROW_IF_BACKEND_MODEL_ORT_ERROR(ort_api->AddSessionConfigEntry(
-            soptions, use_device_allocator_for_initializers_key,
-            string_value.c_str()));
+            LOG_MESSAGE(
+                TRITONSERVER_LOG_INFO,
+                (std::string("Configuring '") + param_key +
+                 "' to '" + string_value + "' for '" + Name() + "'")
+                    .c_str());
+            THROW_IF_BACKEND_MODEL_ORT_ERROR(ort_api->AddSessionConfigEntry(
+                soptions, param_key.c_str(), string_value.c_str()));
+          }
+        }
       }
     }
   }

--- a/src/onnxruntime.cc
+++ b/src/onnxruntime.cc
@@ -286,6 +286,28 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
     }
 
     {
+      triton::common::TritonJson::Value params;
+      if (ModelConfig().Find("parameters", &params)) {
+        triton::common::TritonJson::Value json_value;
+        const char* intra_op_allow_spinning_key =
+            "session.intra_op.allow_spinning";
+        if (params.Find(intra_op_allow_spinning_key, &json_value)) {
+          std::string string_value;
+          THROW_IF_BACKEND_MODEL_ERROR(
+              json_value.MemberAsString("string_value", &string_value));
+
+          LOG_MESSAGE(
+              TRITONSERVER_LOG_VERBOSE,
+              (std::string("Configuring '") + intra_op_allow_spinning_key +
+               "' to '" + string_value + "' for '" + Name() + "'")
+                  .c_str());
+          THROW_IF_BACKEND_MODEL_ORT_ERROR(ort_api->AddSessionConfigEntry(
+              soptions, intra_op_allow_spinning_key, string_value.c_str()));
+        }
+      }
+    }
+
+    {
       // Sets the number of threads used to parallelize the execution of the
       // graph (across nodes) If sequential execution is enabled this value is
       // ignored A value of 0 means ORT will pick a default
@@ -298,6 +320,28 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
       if (inter_op_thread_count > 0) {
         THROW_IF_BACKEND_MODEL_ORT_ERROR(
             ort_api->SetInterOpNumThreads(soptions, inter_op_thread_count));
+      }
+    }
+
+    {
+      triton::common::TritonJson::Value params;
+      if (ModelConfig().Find("parameters", &params)) {
+        triton::common::TritonJson::Value json_value;
+        const char* inter_op_allow_spinning_key =
+            "session.inter_op.allow_spinning";
+        if (params.Find(inter_op_allow_spinning_key, &json_value)) {
+          std::string string_value;
+          THROW_IF_BACKEND_MODEL_ERROR(
+              json_value.MemberAsString("string_value", &string_value));
+
+          LOG_MESSAGE(
+              TRITONSERVER_LOG_VERBOSE,
+              (std::string("Configuring '") + inter_op_allow_spinning_key +
+               "' to '" + string_value + "' for '" + Name() + "'")
+                  .c_str());
+          THROW_IF_BACKEND_MODEL_ORT_ERROR(ort_api->AddSessionConfigEntry(
+              soptions, inter_op_allow_spinning_key, string_value.c_str()));
+        }
       }
     }
   }

--- a/src/onnxruntime_loader.cc
+++ b/src/onnxruntime_loader.cc
@@ -99,6 +99,13 @@ OnnxLoader::Init(common::TritonJson::Value& backend_config)
                   threading_options, inter_op_num_threads));
             }
           }
+          if (cmdline.Find("allow_spinning", &value)) {
+            bool allow_spinning = false;
+            RETURN_IF_ERROR(value.AsString(&value_str));
+            RETURN_IF_ERROR(ParseBoolValue(value_str, &allow_spinning));
+            RETURN_IF_ORT_ERROR(ort_api->SetGlobalSpinControl(
+                threading_options, allow_spinning ? 1 : 0));
+          }
         }
       }
     }

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -34,46 +34,6 @@ import re
 FLAGS = None
 
 OPENVINO_VERSION_MAP = {
-    "2024.0.0": (
-        "2024.0",  # OpenVINO short version
-        "2024.0.0.14509.34caeefd078",  # OpenVINO version with build number
-    ),
-    "2024.1.0": (
-        "2024.1",  # OpenVINO short version
-        "2024.1.0.15008.f4afc983258",  # OpenVINO version with build number
-    ),
-    "2024.4.0": (
-        "2024.4",  # OpenVINO short version
-        "2024.4.0.16579.c3152d32c9c",  # OpenVINO version with build number
-    ),
-    "2024.5.0": (
-        "2024.5",  # OpenVINO short version
-        "2024.5.0.17288.7975fa5da0c",  # OpenVINO version with build number
-    ),
-    "2025.0.0": (
-        "2025.0",  # OpenVINO short version
-        "2025.0.0.17942.1f68be9f594",  # OpenVINO version with build number
-    ),
-    "2025.1.0": (
-        "2025.1",  # OpenVINO short version
-        "2025.1.0.18503.6fec06580ab",  # OpenVINO version with build number
-    ),
-    "2025.2.0": (
-        "2025.2",  # OpenVINO short version
-        "2025.2.0.19140.c01cd93e24d",  # OpenVINO version with build number
-    ),
-    "2025.3.0": (
-        "2025.3",  # OpenVINO short version
-        "2025.3.0.19807.44526285f24",  # OpenVINO version with build number
-    ),
-    "2025.4.0": (
-        "2025.4",  # OpenVINO short version
-        "2025.4.0.20398.8fdad55727d",  # OpenVINO version with build number
-    ),
-    "2025.4.1": (
-        "2025.4.1",  # OpenVINO short version
-        "2025.4.1.20426.82bbf0292c5",  # OpenVINO version with build number
-    ),
     "2026.0.0": (
         "2026.0",  # OpenVINO short version
         "2026.0.0.20965.c6d6a13a886",  # OpenVINO version with build number
@@ -85,6 +45,10 @@ OPENVINO_VERSION_MAP = {
     "2026.2.0": (
         "2026.2",  # OpenVINO short version
         "2026.2.0.21903.52ddc073857",  # OpenVINO version with build number
+    ),
+    "2026.3.0": (
+        "2026.3",  # OpenVINO short version
+        "2026.3.0.22451.bd8d6542e3c",  # OpenVINO version with build number
     ),
 }
 
@@ -238,15 +202,16 @@ RUN dnf install -y \\
         gnupg \\
         openssl-devel \\
         python3.12-devel \\
-        python3.12-pip \\
         wget \\
         zip
 
+ENV PATH="/opt/_internal/pipx/shared/bin:$PATH"
 RUN pip3 install \\
        cmake==4.0.3 \\
        numpy \\
        packaging \\
        patchelf==0.17.2 \\
+       setuptools \\
        wheel>=0.35.1
 
 """
@@ -402,11 +367,7 @@ ARG ONNXRUNTIME_VERSION
 ARG ONNXRUNTIME_REPO
 ARG ONNXRUNTIME_BUILD_CONFIG
 
-RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime && \\
-    (cd onnxruntime && \\
-     git config --global user.email "onnxruntime_backend@nvidia.com" && \\
-     git config --global user.name "onnxruntime_backend" && \\
-     git cherry-pick 5b36110635b51216e40b6aa7aedac392ca44e075 )
+RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime
         """
 
     if FLAGS.onnx_tensorrt_tag != "":
@@ -492,7 +453,8 @@ WORKDIR /opt/onnxruntime/include
 RUN cp /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_c_api.h . \\
     && cp /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h . \\
     && cp /workspace/onnxruntime/include/onnxruntime/core/providers/cpu/cpu_provider_factory.h . \\
-    && cp /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_ep_c_api.h .
+    && cp /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_ep_c_api.h . \\
+    && cp /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_error_code.h .
 
 WORKDIR /opt/onnxruntime/lib
 RUN cp /workspace/build/${ONNXRUNTIME_BUILD_CONFIG}/libonnxruntime_providers_shared.so . \\


### PR DESCRIPTION
Fix: https://github.com/triton-inference-server/onnxruntime_backend/issues/260

Replace hardcoded OpenVINO provider options with dynamic parameter parsing from model configuration. Parse parameters from execution accelerator config, maintain device_type default as CPU when not specified, and use SessionOptionsAppendExecutionProvider_OpenVINO_V2 API with key-value arrays, which is introduced since 1.17, latest triton server releases with 1.23.0
