### PR TITLE
chore: Update/bump OpenVINO version 2026.1

### DIFF
--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -77,6 +77,10 @@ OPENVINO_VERSION_MAP = {
         "2026.0",  # OpenVINO short version
         "2026.0.0.20965.c6d6a13a886",  # OpenVINO version with build number
     ),
+    "2026.1.0": (
+        "2026.1",  # OpenVINO short version
+        "2026.1.0.21367.63e31528c62",  # OpenVINO version with build number
+    ),
 }
 
 


### PR DESCRIPTION
<sup>
</sup>

#### What does the PR do?
Bumps the OpenVINO version used by the ORT dockerfile generator to `2026.1.0`, aligning onnxruntime_backend with the OpenVINO version shipped by the rest of the 26.04 release stack (server + tritonserver).

#### Commit Type:
- [ ] build
- [ ] ci
- [x] chore
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
- triton-inference-server/server#8757

#### Where should the reviewer start?
`tools/gen_ort_dockerfile.py` — only file changed; diff is the OpenVINO version constant.

#### Test plan:
- CI Pipeline ID: 49332301

#### Caveats:
None.

#### Background
Part of TRI-988 — "ci: Enable Perf Analyzer + OpenVINO 2026.1.0".

#### Related Issues:
- Resolves: TRI-988