### PR TITLE
post: Advance main to 26.05dev

### DIFF
--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -77,6 +77,10 @@ OPENVINO_VERSION_MAP = {
         "2026.0",  # OpenVINO short version
         "2026.0.0.20965.c6d6a13a886",  # OpenVINO version with build number
     ),
+    "2026.1.0": (
+        "2026.1",  # OpenVINO short version
+        "2026.1.0.21367.63e31528c62",  # OpenVINO version with build number
+    ),
 }
 
 


### PR DESCRIPTION
<sup>CI (internal): [#49752351](http://tritonserver.local/ci/pipelines/49752351)</sup>

#### What does the PR do?

Bumps OpenVINO version to 2026.1 in the Dockerfile generator script, aligning with the 26.04 release.

Changed files include: `tools/gen_ort_dockerfile.py`.

#### Checklist

- [x] I have made sure this PR is not a duplicate.
- [x] I have made sure the commit message is clear and follows [Conventional Commits](https://www.conventionalcommits.org/).
- [ ] I have added unit tests for any new functionality.
- [x] I have made sure all tests are passing.
- [ ] For documentation changes: I have previewed the changes and they render correctly.

#### Commit Type:

- [ ] `feat` (A new feature)
- [ ] `fix` (A bug fix)
- [ ] `docs` (Documentation-only changes)
- [ ] `style` (Changes that do not affect the meaning of the code — formatting, whitespace, etc.)
- [ ] `refactor` (A code change that neither fixes a bug nor adds a feature)
- [ ] `perf` (A code change that improves performance)
- [ ] `test` (Adding missing tests or correcting existing tests)
- [x] `build` (Changes that affect the build system or external dependencies)
- [ ] `ci` (Changes to CI configuration files and scripts)
- [ ] `chore` (Other changes that don't modify src or test files)

#### Related PRs:

- triton-inference-server/server#8760
- triton-inference-server/client#893
- triton-inference-server/model_analyzer#1021
- triton-inference-server/perf_analyzer#462

#### Where should the reviewer start?

`tools/gen_ort_dockerfile.py`

#### Test plan:

Release-maintenance change; no new behaviour introduced.

- CI Pipeline ID: 49752351

#### Caveats:

None.

#### Background

Part of TRI-912 post-26.04 release maintenance: advance all Triton `main`/`master` branches to 26.05 / 2.69.0dev before the NGC 26.04 container is published.

#### Related Issues:

Resolves: TRI-912