### PR TITLE
ci(TRI-1406): prepare ONNX Runtime backend for 26.06 (TRT 11, OV 2026.2, CCCL fix)

### DIFF
--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -343,10 +343,12 @@ ARG ONNXRUNTIME_REPO
 ARG ONNXRUNTIME_BUILD_CONFIG
 
 RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime && \\
-    (cd onnxruntime && git checkout v${ONNXRUNTIME_VERSION} && \\
+    ( cd onnxruntime && git checkout v${ONNXRUNTIME_VERSION} && \\
     git config --global user.email "onnxruntime_backend@nvidia.com" && \\
     git config --global user.name "onnxruntime_backend" && \\
-    git cherry-pick 53fcead6c747330dd69ac6b960972b535042b3ff ) && \\
+    git cherry-pick 53fcead6c747330dd69ac6b960972b535042b3ff && \\
+    git fetch origin pull/28586/head:ort-pr-abseil-nvcc && \\
+    git cherry-pick ort-pr-abseil-nvcc ) && \\
     cd onnxruntime && git submodule update --init --recursive
         """
 

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -346,11 +346,7 @@ RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnx
     ( cd onnxruntime && git checkout v${ONNXRUNTIME_VERSION} && \\
     git config --global user.email "onnxruntime_backend@nvidia.com" && \\
     git config --global user.name "onnxruntime_backend" && \\
-    git cherry-pick 53fcead6c747330dd69ac6b960972b535042b3ff && \\
-    git fetch origin pull/28586/head:ort-pr-abseil-nvcc && \\
-    git cherry-pick ort-pr-abseil-nvcc && \\
-    git fetch origin pull/28972/head:ort-pr-cccl-header-order && \\
-    git cherry-pick ort-pr-cccl-header-order ) && \\
+    git cherry-pick 53fcead6c747330dd69ac6b960972b535042b3ff ) && \\
     cd onnxruntime && git submodule update --init --recursive
         """
 

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -81,6 +81,10 @@ OPENVINO_VERSION_MAP = {
         "2026.1",  # OpenVINO short version
         "2026.1.0.21367.63e31528c62",  # OpenVINO version with build number
     ),
+    "2026.2.0": (
+        "2026.2",  # OpenVINO short version
+        "2026.2.0.21903.52ddc073857",  # OpenVINO version with build number
+    ),
 }
 
 

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -343,6 +343,10 @@ ARG ONNXRUNTIME_REPO
 ARG ONNXRUNTIME_BUILD_CONFIG
 
 RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime && \\
+    (cd onnxruntime && git checkout v${ONNXRUNTIME_VERSION} && \\
+    git config --global user.email "onnxruntime_backend@nvidia.com" && \\
+    git config --global user.name "onnxruntime_backend" && \\
+    git cherry-pick 53fcead6c747330dd69ac6b960972b535042b3ff ) && \\
     cd onnxruntime && git submodule update --init --recursive
         """
 

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -348,7 +348,9 @@ RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnx
     git config --global user.name "onnxruntime_backend" && \\
     git cherry-pick 53fcead6c747330dd69ac6b960972b535042b3ff && \\
     git fetch origin pull/28586/head:ort-pr-abseil-nvcc && \\
-    git cherry-pick ort-pr-abseil-nvcc ) && \\
+    git cherry-pick ort-pr-abseil-nvcc && \\
+    git fetch origin pull/28972/head:ort-pr-cccl-header-order && \\
+    git cherry-pick ort-pr-cccl-header-order ) && \\
     cd onnxruntime && git submodule update --init --recursive
         """
 


### PR DESCRIPTION
#### What does the PR do?
Prepare the ONNX Runtime backend for the 26.06 release train: pick up OpenVINO 2026.2, TensorRT 11 support, and the cherry-picked upstream ORT fix for CCCL header ordering required by the new CUDA stack.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [ ] Populated github labels field
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging.
- [x] All template sections are filled out.

#### Commit Type:
- [x] ci

#### Related PRs:
triton-inference-server/server#8828

#### Where should the reviewer start?
- `tools/gen_ort_dockerfile.py` — TensorRT 11, OpenVINO 2026.2, and the ORT PR #28972 (CCCL header-ordering) patch.

#### Test plan:
Validated by triggering a tritonserver pipeline that builds the ONNX Runtime backend with the new upstream stack.
- CI Pipeline ID:

#### Caveats:
Picks an upstream ORT patch (#28972) ahead of an official ORT release tag. Drop the patch once the corresponding ORT release is consumed.

#### Background
Required by the 26.06 release train — see [Build against latest upstream container](https://nvidia.atlassian.net/wiki/spaces/DL/pages/2822886305/#Build-against-latest-upstream-container).

#### Related Issues:
- Resolves TRI-1406
