### PR TITLE
ci(TRI-1406): prepare ONNX Runtime backend for 26.06 (TRT 11, OV 2026.2, CCCL fix) (cherry-pick)

### DIFF
--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -81,6 +81,10 @@ OPENVINO_VERSION_MAP = {
         "2026.1",  # OpenVINO short version
         "2026.1.0.21367.63e31528c62",  # OpenVINO version with build number
     ),
+    "2026.2.0": (
+        "2026.2",  # OpenVINO short version
+        "2026.2.0.21903.52ddc073857",  # OpenVINO version with build number
+    ),
 }
 
 
@@ -339,6 +343,10 @@ ARG ONNXRUNTIME_REPO
 ARG ONNXRUNTIME_BUILD_CONFIG
 
 RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime && \\
+    ( cd onnxruntime && git checkout v${ONNXRUNTIME_VERSION} && \\
+    git config --global user.email "onnxruntime_backend@nvidia.com" && \\
+    git config --global user.name "onnxruntime_backend" && \\
+    git cherry-pick 53fcead6c747330dd69ac6b960972b535042b3ff ) && \\
     cd onnxruntime && git submodule update --init --recursive
         """
 


### PR DESCRIPTION
#### What does the PR do?
Cherry-picks `7db2534` from `r26.06` to advance `main` post-26.05 toward the 26.07dev_user container train (tracks upstream 26.06).

Brings forward 26.06-cycle changes to `tools/gen_ort_dockerfile.py`: OpenVINO 2026.2, TensorRT 11, and the ORT `#28972` CCCL header-ordering fix.

#### Related PRs:
- triton-inference-server/server#8861
- triton-inference-server/core#505
- triton-inference-server/client#905
- triton-inference-server/tensorrt_backend#122
- triton-inference-server/tutorials#152
- triton-inference-server/model_analyzer#1027

#### Test plan:
- `gen_ort_dockerfile.py` renders the expected Dockerfile against CUDA 13.3 / TRT 11.
- CI Pipeline ID: TBD

#### Related Issues:
- Resolves: TRI-1431