### PR TITLE
build: add OpenVINO 2026.2.0 and cherry-pick ORT build fix

### DIFF
--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -344,7 +344,7 @@ ARG ONNXRUNTIME_BUILD_CONFIG
 
 RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime && \\
     (cd onnxruntime && \\
-     git fetch upstream pull/28611/head:ort-pr-trt11 pull/28586/head:ort-pr-abseil-nvcc && \\
+     git fetch origin pull/28611/head:ort-pr-trt11 pull/28586/head:ort-pr-abseil-nvcc && \\
      git cherry-pick ort-pr-trt11 && \\
      git cherry-pick ort-pr-abseil-nvcc)
         """

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -346,9 +346,7 @@ RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnx
     (cd onnxruntime && \\
      git config --global user.email "onnxruntime_backend@nvidia.com" && \\
      git config --global user.name "onnxruntime_backend" && \\
-     git fetch origin pull/28611/head:ort-pr-trt11 pull/28586/head:ort-pr-abseil-nvcc && \\
-     git cherry-pick ort-pr-trt11 && \\
-     git cherry-pick ort-pr-abseil-nvcc)
+     git cherry-pick 5b36110635b51216e40b6aa7aedac392ca44e075 )
         """
 
     if FLAGS.onnx_tensorrt_tag != "":

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -344,6 +344,8 @@ ARG ONNXRUNTIME_BUILD_CONFIG
 
 RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime && \\
     (cd onnxruntime && \\
+     git config --global user.email "onnxruntime_backend@nvidia.com" && \\
+     git config --global user.name "onnxruntime_backend" && \\
      git fetch origin pull/28611/head:ort-pr-trt11 pull/28586/head:ort-pr-abseil-nvcc && \\
      git cherry-pick ort-pr-trt11 && \\
      git cherry-pick ort-pr-abseil-nvcc)

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -135,7 +135,7 @@ def dockerfile_common():
     df = """
 ARG BASE_IMAGE={}
 ARG ONNXRUNTIME_VERSION={}
-ARG ONNXRUNTIME_REPO=https://github.com/mc-nv/onnxruntime
+ARG ONNXRUNTIME_REPO=https://github.com/microsoft/onnxruntime
 ARG ONNXRUNTIME_BUILD_CONFIG={}
 """.format(
         FLAGS.triton_container, FLAGS.ort_version, FLAGS.ort_build_config
@@ -342,7 +342,7 @@ ARG ONNXRUNTIME_VERSION
 ARG ONNXRUNTIME_REPO
 ARG ONNXRUNTIME_BUILD_CONFIG
 
-RUN git clone -b mchornyi/TRI-704/onnx --recursive ${ONNXRUNTIME_REPO} onnxruntime && \\
+RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime && \\
     cd onnxruntime && git submodule update --init --recursive
         """
 

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -135,7 +135,7 @@ def dockerfile_common():
     df = """
 ARG BASE_IMAGE={}
 ARG ONNXRUNTIME_VERSION={}
-ARG ONNXRUNTIME_REPO=https://github.com/microsoft/onnxruntime
+ARG ONNXRUNTIME_REPO=https://github.com/mc-nv/onnxruntime
 ARG ONNXRUNTIME_BUILD_CONFIG={}
 """.format(
         FLAGS.triton_container, FLAGS.ort_version, FLAGS.ort_build_config
@@ -342,11 +342,7 @@ ARG ONNXRUNTIME_VERSION
 ARG ONNXRUNTIME_REPO
 ARG ONNXRUNTIME_BUILD_CONFIG
 
-RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime && \\
-    ( cd onnxruntime && git checkout v${ONNXRUNTIME_VERSION} && \\
-    git config --global user.email "onnxruntime_backend@nvidia.com" && \\
-    git config --global user.name "onnxruntime_backend" && \\
-    git cherry-pick 53fcead6c747330dd69ac6b960972b535042b3ff ) && \\
+RUN git clone -b mchornyi/TRI-704/onnx --recursive ${ONNXRUNTIME_REPO} onnxruntime && \\
     cd onnxruntime && git submodule update --init --recursive
         """
 

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -343,7 +343,10 @@ ARG ONNXRUNTIME_REPO
 ARG ONNXRUNTIME_BUILD_CONFIG
 
 RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime && \\
-    cd onnxruntime && git submodule update --init --recursive
+    (cd onnxruntime && \\
+     git fetch upstream pull/28611/head:ort-pr-trt11 pull/28586/head:ort-pr-abseil-nvcc && \\
+     git cherry-pick ort-pr-trt11 && \\
+     git cherry-pick ort-pr-abseil-nvcc)
         """
 
     if FLAGS.onnx_tensorrt_tag != "":


### PR DESCRIPTION
#### What does the PR do?
Updates the ONNX Runtime backend Dockerfile generator for the Vera Rubin (R100 / R200)
build train:
- Adds the OpenVINO `2026.2.0` entry to `OPENVINO_VERSION_MAP`.
- Cherry-picks an upstream ONNX Runtime build fix during the `git clone` step
  (commit `5b36110`), with a CI-local git identity so the cherry-pick succeeds.

#### Commit Type:
- [x] build

#### Related PRs:
triton-inference-server/server#8867

#### Where should the reviewer start?
`tools/gen_ort_dockerfile.py` — `OPENVINO_VERSION_MAP` and the ONNX Runtime clone/build step.

#### Test plan:
ONNX Runtime backend image builds in the rubin pipeline on the internal GitLab mirror with
OpenVINO 2026.2.0 and the cherry-picked ORT fix.

- CI Pipeline ID: 56420653

#### Background
Part of Vera Rubin (R100 / R200) CI enablement; pairs with the upstream/ORT version bump in
triton-inference-server/server#8867.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to TRI-1167
- Relates to TRI-1171
