### PR TITLE
fix(build): cap ONNX Runtime build parallelism to avoid runner OOM (#348)

### DIFF
--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -26,6 +26,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import multiprocessing
 import os
 import platform
 import re
@@ -86,6 +87,65 @@ OPENVINO_VERSION_MAP = {
         "2026.2.0.21903.52ddc073857",  # OpenVINO version with build number
     ),
 }
+
+
+def usable_cpu_count():
+    # Honor CPU affinity / cgroup pinning where available (Linux); fall back to
+    # the logical core count on platforms without sched_getaffinity.
+    try:
+        return len(os.sched_getaffinity(0))
+    except AttributeError:
+        return multiprocessing.cpu_count() or 1
+
+
+def available_memory_gb():
+    # Best-effort available RAM in GiB, or None if it cannot be determined.
+    # Reads MemAvailable from /proc/meminfo (Linux); returns None elsewhere so
+    # callers fall back to a CPU-only parallelism default.
+    try:
+        with open("/proc/meminfo") as f:
+            for line in f:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) / (1024 * 1024)
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
+# Memory budget the build is assumed to have for compilation. Parallelism is
+# sized so the ONNX Runtime build's peak memory stays within this, leaving the
+# rest of the host free and avoiding OOM on swap-less builders (see TRI-1550).
+MAX_BUILD_MEMORY_GB = 64.0
+
+# Approximate RAM headroom reserved per concurrent compiler slot.
+MEM_GB_PER_SLOT = 2.0
+
+
+def build_parallelism(nvcc_threads):
+    # Cap ONNX Runtime build parallelism to avoid OOM on swap-less builders
+    # (see TRI-1550). Bare `--parallel` expands to cpu_count(), which combined
+    # with per-nvcc multi-arch compilation exhausts memory. Each concurrent
+    # compiler slot is budgeted ~MEM_GB_PER_SLOT of RAM, and the product
+    # `parallel_jobs * nvcc_threads` is bounded by that budget.
+    #
+    # The assumed memory budget is capped at MAX_BUILD_MEMORY_GB: we never plan
+    # for more than that (so a big-RAM host doesn't over-subscribe), nor for
+    # more than is actually available (so a small builder doesn't OOM). When the
+    # available memory is unknown, we fall back to the MAX_BUILD_MEMORY_GB
+    # assumption rather than to an unbounded core count.
+    #
+    # Computed at Dockerfile-generation time (same host that runs `docker
+    # build`), matching server/build.py; the resulting values are baked into
+    # the Dockerfile as literals so no shell logic runs in the build stage.
+    cpus = usable_cpu_count()
+
+    mem_gb = available_memory_gb()
+    budget_gb = (
+        min(mem_gb, MAX_BUILD_MEMORY_GB) if mem_gb is not None else MAX_BUILD_MEMORY_GB
+    )
+
+    mem_slots = max(1, int(budget_gb // MEM_GB_PER_SLOT))
+    return max(1, min(cpus, mem_slots // max(1, nvcc_threads)))
 
 
 def parse_cuda_arch_list(raw):
@@ -391,16 +451,32 @@ RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnx
 
     df += """
 WORKDIR /workspace/onnxruntime
-ARG COMMON_BUILD_ARGS="--config ${{ONNXRUNTIME_BUILD_CONFIG}} --parallel --skip_submodule_sync --build_shared_lib \
+ARG COMMON_BUILD_ARGS="--config ${{ONNXRUNTIME_BUILD_CONFIG}} --skip_submodule_sync --build_shared_lib \
     --compile_no_warning_as_error --build_dir /workspace/build --cmake_extra_defines CMAKE_CUDA_ARCHITECTURES='{}'  --cmake_extra_defines CMAKE_POLICY_VERSION_MINIMUM=3.5 --build_wheel"
 """.format(
         cuda_archs
     )
 
+    # Cap ONNX Runtime build parallelism to avoid OOM on swap-less builders
+    # (see TRI-1550). Values are computed in Python and baked in as literals so
+    # the build stage stays free of shell logic (portable across Debian/RHEL).
+    nvcc_threads = 2
+    ort_jobs = build_parallelism(nvcc_threads)
+    print(
+        "[INFO] ONNX Runtime build parallelism: --parallel {} --nvcc_threads {} "
+        "(usable cores {}, MemAvailable {})".format(
+            ort_jobs,
+            nvcc_threads,
+            usable_cpu_count(),
+            "{:.1f} GB".format(available_memory_gb())
+            if available_memory_gb() is not None
+            else "unknown",
+        )
+    )
     df += """
-RUN ./build.sh ${{COMMON_BUILD_ARGS}} --update --build {}
+RUN ./build.sh ${{COMMON_BUILD_ARGS}} --parallel {} --nvcc_threads {} --update --build {}
 """.format(
-        ep_flags
+        ort_jobs, nvcc_threads, ep_flags
     )
 
     df += """


### PR DESCRIPTION
#### What does the PR do?
Cherry-pick of triton-inference-server/onnxruntime_backend#348 to **r26.07**.

Caps ONNX Runtime build parallelism in the generated Dockerfile (bare `--parallel` →
Python-computed `--parallel <jobs> --nvcc_threads 2`, bounded by a ~2 GB/slot memory budget
capped at 64 GB) so the nested ORT build no longer OOMs swap-less runners. No functional
differences from the original; clean cherry-pick.

#### Related PRs:
triton-inference-server/server#8875

#### Related Issues:
- Relates to: TRI-1550
