### PR TITLE
build(before-code-freeze): Prepare the ONNX Runtime backend for the manylinux base

### DIFF
--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -205,7 +205,7 @@ RUN dnf install -y \\
         wget \\
         zip
 
-RUN . /opt/_internal/pipx/shared/bin/activate
+ENV PATH="/opt/_internal/pipx/shared/bin:$PATH"
 RUN pip3 install \\
        cmake==4.0.3 \\
        numpy \\

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -366,11 +366,7 @@ ARG ONNXRUNTIME_VERSION
 ARG ONNXRUNTIME_REPO
 ARG ONNXRUNTIME_BUILD_CONFIG
 
-RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime && \\
-    (cd onnxruntime && \\
-     git config --global user.email "onnxruntime_backend@nvidia.com" && \\
-     git config --global user.name "onnxruntime_backend" && \\
-     git cherry-pick 5b36110635b51216e40b6aa7aedac392ca44e075 )
+RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime
         """
 
     if FLAGS.onnx_tensorrt_tag != "":

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -452,7 +452,8 @@ WORKDIR /opt/onnxruntime/include
 RUN cp /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_c_api.h . \\
     && cp /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h . \\
     && cp /workspace/onnxruntime/include/onnxruntime/core/providers/cpu/cpu_provider_factory.h . \\
-    && cp /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_ep_c_api.h .
+    && cp /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_ep_c_api.h . \\
+    && cp /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_error_code.h .
 
 WORKDIR /opt/onnxruntime/lib
 RUN cp /workspace/build/${ONNXRUNTIME_BUILD_CONFIG}/libonnxruntime_providers_shared.so . \\

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -202,10 +202,10 @@ RUN dnf install -y \\
         gnupg \\
         openssl-devel \\
         python3.12-devel \\
-        python3.12-pip \\
         wget \\
         zip
 
+RUN . /opt/_internal/pipx/shared/bin/activate
 RUN pip3 install \\
        cmake==4.0.3 \\
        numpy \\

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -211,6 +211,7 @@ RUN pip3 install \\
        numpy \\
        packaging \\
        patchelf==0.17.2 \\
+       setuptools \\
        wheel>=0.35.1
 
 """

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -34,46 +34,6 @@ import re
 FLAGS = None
 
 OPENVINO_VERSION_MAP = {
-    "2024.0.0": (
-        "2024.0",  # OpenVINO short version
-        "2024.0.0.14509.34caeefd078",  # OpenVINO version with build number
-    ),
-    "2024.1.0": (
-        "2024.1",  # OpenVINO short version
-        "2024.1.0.15008.f4afc983258",  # OpenVINO version with build number
-    ),
-    "2024.4.0": (
-        "2024.4",  # OpenVINO short version
-        "2024.4.0.16579.c3152d32c9c",  # OpenVINO version with build number
-    ),
-    "2024.5.0": (
-        "2024.5",  # OpenVINO short version
-        "2024.5.0.17288.7975fa5da0c",  # OpenVINO version with build number
-    ),
-    "2025.0.0": (
-        "2025.0",  # OpenVINO short version
-        "2025.0.0.17942.1f68be9f594",  # OpenVINO version with build number
-    ),
-    "2025.1.0": (
-        "2025.1",  # OpenVINO short version
-        "2025.1.0.18503.6fec06580ab",  # OpenVINO version with build number
-    ),
-    "2025.2.0": (
-        "2025.2",  # OpenVINO short version
-        "2025.2.0.19140.c01cd93e24d",  # OpenVINO version with build number
-    ),
-    "2025.3.0": (
-        "2025.3",  # OpenVINO short version
-        "2025.3.0.19807.44526285f24",  # OpenVINO version with build number
-    ),
-    "2025.4.0": (
-        "2025.4",  # OpenVINO short version
-        "2025.4.0.20398.8fdad55727d",  # OpenVINO version with build number
-    ),
-    "2025.4.1": (
-        "2025.4.1",  # OpenVINO short version
-        "2025.4.1.20426.82bbf0292c5",  # OpenVINO version with build number
-    ),
     "2026.0.0": (
         "2026.0",  # OpenVINO short version
         "2026.0.0.20965.c6d6a13a886",  # OpenVINO version with build number
@@ -85,6 +45,10 @@ OPENVINO_VERSION_MAP = {
     "2026.2.0": (
         "2026.2",  # OpenVINO short version
         "2026.2.0.21903.52ddc073857",  # OpenVINO version with build number
+    ),
+    "2026.3.0": (
+        "2026.3",  # OpenVINO short version
+        "2026.3.0.22451.bd8d6542e3c",  # OpenVINO version with build number
     ),
 }
 


### PR DESCRIPTION
#### What does the PR do?
Prepare the ONNX Runtime backend for the 26.08 manylinux base:
- add `setuptools` to the RHEL pip list -- ORT's `--build_wheel` step runs
  `setup.py bdist_wheel` under the pipx interpreter, and Python 3.12 no longer
  bootstraps setuptools, so the wheel step failed with `ModuleNotFoundError`.
- switch to the default pipx environment and the env-var form for the Python location.
- copy `onnxruntime_error_code.h`, new in ORT 1.28.
- bump OpenVINO to 2026.3.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated github labels field
- [ ] Added test plan and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging.
- [x] All template sections are filled out.

#### Commit Type:
- [x] build
- [x] fix

#### Related PRs:
- triton-inference-server/common#162
- triton-inference-server/python_backend#451
- triton-inference-server/pytorch_backend#204
- triton-inference-server/server#8918

#### Where should the reviewer start?
`tools/gen_ort_dockerfile.py`.

#### Test plan:
Covered by the internal RHEL/manylinux pipeline for the 26.08 upstream bump.

- CI Pipeline ID: 61271932

#### Caveats:
`onnxruntime_error_code.h` exists only from ORT 1.28 (404 at `rel-1.27.0`, 200 at
`rel-1.28.0`). Any job still pinning ORT 1.27 will fail the header copy -- the
non-RHEL path builds `server@main`, which pins 1.27.0 while `server/build.py`
defaults to 1.28.0.

#### Background
Part of the 26.08 "build against latest upstream container" work: the base image
moved to `cuda:13.4-devel-manylinux--26.08`, which changed the default GCC
toolset, the Python layout and the bundled OpenSSL.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Resolves: TRI-1650

<sup>
CI (internal): [#61271932](http://tritonserver.local/ci/pipelines/61271932)<br/>
</sup>
