### PR TITLE
build(before-code-freeze): Prepare the ONNX Runtime backend for the manylinux base (#352)

### DIFF
--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -34,46 +34,6 @@ import re
 FLAGS = None
 
 OPENVINO_VERSION_MAP = {
-    "2024.0.0": (
-        "2024.0",  # OpenVINO short version
-        "2024.0.0.14509.34caeefd078",  # OpenVINO version with build number
-    ),
-    "2024.1.0": (
-        "2024.1",  # OpenVINO short version
-        "2024.1.0.15008.f4afc983258",  # OpenVINO version with build number
-    ),
-    "2024.4.0": (
-        "2024.4",  # OpenVINO short version
-        "2024.4.0.16579.c3152d32c9c",  # OpenVINO version with build number
-    ),
-    "2024.5.0": (
-        "2024.5",  # OpenVINO short version
-        "2024.5.0.17288.7975fa5da0c",  # OpenVINO version with build number
-    ),
-    "2025.0.0": (
-        "2025.0",  # OpenVINO short version
-        "2025.0.0.17942.1f68be9f594",  # OpenVINO version with build number
-    ),
-    "2025.1.0": (
-        "2025.1",  # OpenVINO short version
-        "2025.1.0.18503.6fec06580ab",  # OpenVINO version with build number
-    ),
-    "2025.2.0": (
-        "2025.2",  # OpenVINO short version
-        "2025.2.0.19140.c01cd93e24d",  # OpenVINO version with build number
-    ),
-    "2025.3.0": (
-        "2025.3",  # OpenVINO short version
-        "2025.3.0.19807.44526285f24",  # OpenVINO version with build number
-    ),
-    "2025.4.0": (
-        "2025.4",  # OpenVINO short version
-        "2025.4.0.20398.8fdad55727d",  # OpenVINO version with build number
-    ),
-    "2025.4.1": (
-        "2025.4.1",  # OpenVINO short version
-        "2025.4.1.20426.82bbf0292c5",  # OpenVINO version with build number
-    ),
     "2026.0.0": (
         "2026.0",  # OpenVINO short version
         "2026.0.0.20965.c6d6a13a886",  # OpenVINO version with build number
@@ -85,6 +45,10 @@ OPENVINO_VERSION_MAP = {
     "2026.2.0": (
         "2026.2",  # OpenVINO short version
         "2026.2.0.21903.52ddc073857",  # OpenVINO version with build number
+    ),
+    "2026.3.0": (
+        "2026.3",  # OpenVINO short version
+        "2026.3.0.22451.bd8d6542e3c",  # OpenVINO version with build number
     ),
 }
 
@@ -238,15 +202,16 @@ RUN dnf install -y \\
         gnupg \\
         openssl-devel \\
         python3.12-devel \\
-        python3.12-pip \\
         wget \\
         zip
 
+ENV PATH="/opt/_internal/pipx/shared/bin:$PATH"
 RUN pip3 install \\
        cmake==4.0.3 \\
        numpy \\
        packaging \\
        patchelf==0.17.2 \\
+       setuptools \\
        wheel>=0.35.1
 
 """
@@ -402,11 +367,7 @@ ARG ONNXRUNTIME_VERSION
 ARG ONNXRUNTIME_REPO
 ARG ONNXRUNTIME_BUILD_CONFIG
 
-RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime && \\
-    (cd onnxruntime && \\
-     git config --global user.email "onnxruntime_backend@nvidia.com" && \\
-     git config --global user.name "onnxruntime_backend" && \\
-     git cherry-pick 5b36110635b51216e40b6aa7aedac392ca44e075 )
+RUN git clone -b rel-${ONNXRUNTIME_VERSION} --recursive ${ONNXRUNTIME_REPO} onnxruntime
         """
 
     if FLAGS.onnx_tensorrt_tag != "":
@@ -492,7 +453,8 @@ WORKDIR /opt/onnxruntime/include
 RUN cp /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_c_api.h . \\
     && cp /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_session_options_config_keys.h . \\
     && cp /workspace/onnxruntime/include/onnxruntime/core/providers/cpu/cpu_provider_factory.h . \\
-    && cp /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_ep_c_api.h .
+    && cp /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_ep_c_api.h . \\
+    && cp /workspace/onnxruntime/include/onnxruntime/core/session/onnxruntime_error_code.h .
 
 WORKDIR /opt/onnxruntime/lib
 RUN cp /workspace/build/${ONNXRUNTIME_BUILD_CONFIG}/libonnxruntime_providers_shared.so . \\


### PR DESCRIPTION
#### What does the PR do?
- Carries the manylinux preparation forward from `r26.08` onto `main`.
- Needed because `main` now builds against the 26.08 upstream containers, whose base is manylinux.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
- triton-inference-server/client#920
- triton-inference-server/common#164
- triton-inference-server/core#523
- triton-inference-server/python_backend#453
- triton-inference-server/pytorch_backend#209
- triton-inference-server/tutorials#168
- triton-inference-server/server#8949

#### Where should the reviewer start?
`tools/gen_ort_dockerfile.py` — the pyenv path being removed.

#### Test plan:
- Full CI run on the internal pipeline at `TRITON_CONTAINER_VERSION=26.09dev_user`, with `TRITON_NIGHTLY=1` and `TRITON_SBSA=1`.
- Local verification: per-repo `pre-commit run --files <changed>` passes with no auto-fixes.

- CI Pipeline ID:
<!-- pipeline not yet triggered; fill in after the _user run starts -->

#### Caveats:
- Do not merge before the model-repository mount point is rotated: `TRITON_SERVER_MODEL_REPO_VERSION` derives from `TRITON_CONTAINER_VERSION`, so `26.09dev` must exist on the share first.

#### Background
Post-release step of the 26.08 train: the default branches move onto the same upstream containers as the just-released `r26.08`, and pick up the fixes that landed only on the release branch while it stabilised.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to: TRI-1691
