### PR TITLE
build: Update C++ standard from c++17 to c++20 (#359)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -110,8 +110,8 @@ set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 
-# Use C++17 standard as Triton's minimum required.
-set(TRITON_MIN_CXX_STANDARD 17 CACHE STRING "The minimum C++ standard which features are requested to build this target.")
+# Use C++20 standard as Triton's minimum required.
+set(TRITON_MIN_CXX_STANDARD 20 CACHE STRING "The minimum C++ standard which features are requested to build this target.")
 
 if (WIN32)
   if(TRITON_ENABLE_ONNXRUNTIME_OPENVINO)


### PR DESCRIPTION
Cherry-pick of the C++17->C++20 standard bump (TRI-1877) onto `r26.09`.

Upstream PyTorch raised ATen's minimum required C++ standard from 17
to 20 (pytorch/pytorch#178150), which broke the pytorch_backend build.
Align this repo's TRITON_MIN_CXX_STANDARD/CMAKE_CXX_STANDARD default
with that floor for consistency across the stack.

TRI-1877

(cherry picked from commit 7611d8da1d9b70214e4c9929eba0ec0067309d9c)