### PR TITLE
build: Update OpenVINO version to 2026.3.1

### DIFF
--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -50,6 +50,10 @@ OPENVINO_VERSION_MAP = {
         "2026.3",  # OpenVINO short version
         "2026.3.0.22451.bd8d6542e3c",  # OpenVINO version with build number
     ),
+    "2026.3.1": (
+        "2026.3",  # OpenVINO short version
+        "2026.3.1.22476.56d9685302d",  # OpenVINO version with build number
+    ),
 }
 
 


### PR DESCRIPTION
#### What does the PR do?
- Adds the missing `"2026.3.1"` entry to `OPENVINO_VERSION_MAP` in `tools/gen_ort_dockerfile.py`, matching `server/build.py`'s `ort_openvino_version` / `standalone_openvino_version` (`2026.3.1`). Without this entry, `gen_ort_dockerfile.py` raises `KeyError: '2026.3.1'` and fails the ONNXRuntime backend build.

#### Related PRs:
<!-- none for this issue -->

#### Where should the reviewer start?
- `tools/gen_ort_dockerfile.py` — the new `OPENVINO_VERSION_MAP["2026.3.1"]` tuple (short version + build-numbered version string).

#### Test plan:
- CI: GitHub Actions on this PR (`main.yml`).

#### Background
- `server/build.py`'s `DEFAULT_TRITON_VERSION_MAP` was bumped to OpenVINO `2026.3.1` (commit `189b0a9e7`) without a matching entry here, breaking every ONNXRuntime backend build (`gen_ort_dockerfile.py: KeyError: '2026.3.1'`). Root-caused while triaging failing jobs 434651591 / 434651589 on the TRI-1856 branch.

#### Related Issues:
- Resolves: TRI-1855
