### PR TITLE
build: Update OpenVINO version to 2026.3.1

### DIFF
--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -51,7 +51,7 @@ OPENVINO_VERSION_MAP = {
         "2026.3.0.22451.bd8d6542e3c",  # OpenVINO version with build number
     ),
     "2026.3.1": (
-        "2026.3",  # OpenVINO short version
+        "2026.3.1",  # OpenVINO short version
         "2026.3.1.22476.56d9685302d",  # OpenVINO version with build number
     ),
 }

--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -50,6 +50,10 @@ OPENVINO_VERSION_MAP = {
         "2026.3",  # OpenVINO short version
         "2026.3.0.22451.bd8d6542e3c",  # OpenVINO version with build number
     ),
+    "2026.3.1": (
+        "2026.3",  # OpenVINO short version
+        "2026.3.1.22476.56d9685302d",  # OpenVINO version with build number
+    ),
 }
 
 


### PR DESCRIPTION
#### What does the PR do?
- Adds the missing `"2026.3.1"` entry to `OPENVINO_VERSION_MAP` in `tools/gen_ort_dockerfile.py`, matching `server/build.py`'s `ort_openvino_version` / `standalone_openvino_version` (`2026.3.1`). Without this entry, `gen_ort_dockerfile.py` raises `KeyError: '2026.3.1'` and fails the ONNXRuntime backend build.
- Corrects the OpenVINO short version string for that entry from `"2026.3"` to `"2026.3.1"`.

#### Related PRs:
- triton-inference-server/server#8966

#### Where should the reviewer start?
- `tools/gen_ort_dockerfile.py` — the `OPENVINO_VERSION_MAP["2026.3.1"]` tuple (short version + build-numbered version string).

#### Test plan:
- CI: GitHub Actions on this PR (`main.yml`).

#### Background
- `server/build.py`'s `DEFAULT_TRITON_VERSION_MAP` was bumped to OpenVINO `2026.3.1` (commit `189b0a9e7`) without a matching entry here, breaking every ONNXRuntime backend build (`gen_ort_dockerfile.py: KeyError: '2026.3.1'`). Root-caused while triaging failing jobs 434651591 / 434651589 on the TRI-1856 branch.
- Required by triton-inference-server/server#8966 (ONNXRuntime 1.30.0 bump, TRI-1856) — without this fix, that PR's build fails with the same `KeyError`. Land both together.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Resolves: TRI-1855

