### PR TITLE
build: Update OpenVINO version to 2026.3.1

### DIFF
--- a/tools/gen_ort_dockerfile.py
+++ b/tools/gen_ort_dockerfile.py
@@ -50,6 +50,10 @@ OPENVINO_VERSION_MAP = {
         "2026.3",  # OpenVINO short version
         "2026.3.0.22451.bd8d6542e3c",  # OpenVINO version with build number
     ),
+    "2026.3.1": (
+        "2026.3.1",  # OpenVINO short version
+        "2026.3.1.22476.56d9685302d",  # OpenVINO version with build number
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
- Cherry-pick of main commit e52c89b: add the 2026.3.1 entry to `OPENVINO_VERSION_MAP` in `tools/gen_ort_dockerfile.py` for the r26.09 release train

## Test plan
- [ ] N/A (version map addition only)

#### Related Issues:
- Resolves: TRI-1859

#### Related PRs:
- triton-inference-server/server#8968
- triton-inference-server/model_analyzer#1037
- triton-inference-server/tutorials#171
